### PR TITLE
Fixes a compile issue on OSX in dependent packages

### DIFF
--- a/include/class_loader/meta_object.h
+++ b/include/class_loader/meta_object.h
@@ -151,6 +151,7 @@ class AbstractMetaObject : public AbstractMetaObjectBase
     AbstractMetaObject(const std::string& class_name, const std::string& base_class_name) : 
     AbstractMetaObjectBase(class_name, base_class_name)
     {
+        AbstractMetaObjectBase::typeid_base_class_name_ = std::string(typeid(B).name());
     }
 
     /**
@@ -190,7 +191,6 @@ class MetaObject: public AbstractMetaObject<B>
     MetaObject(const std::string& class_name, const std::string& base_class_name) :
     AbstractMetaObject<B>(class_name, base_class_name)
     {
-        AbstractMetaObjectBase::typeid_base_class_name_ = std::string(typeid(B).name());
     }
 
     /**


### PR DESCRIPTION
When building `qt_gui_cpp` on OS X with `class_loader` version 0.1.20 I get this error:

```
==> Processing catkin package: 'qt_gui_cpp'
==> Creating build directory: 'build_isolated/qt_gui_cpp'
==> Building with env: '/Users/william/ros_catkin_ws/install_isolated/env_cached.sh'
==> cmake /Users/william/ros_catkin_ws/src/qt_gui_cpp -DCATKIN_STATIC_ENV=1 -DCATKIN_DEVEL_PREFIX=/Users/william/ros_catkin_ws/devel_isolated/qt_gui_cpp -DCMAKE_INSTALL_PREFIX=/Users/william/ros_catkin_ws/install_isolated
==> make -j4 in '/Users/william/ros_catkin_ws/build_isolated/qt_gui_cpp'
[  7%] Generating __/__/include/qt_gui_cpp/moc_plugin_bridge.cxx
Scanning dependencies of target qt_gui_cpp
[ 23%] [ 30%] [ 30%] [ 38%] Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/composite_plugin_provider.cpp.o
Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/plugin_bridge.cpp.o
Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/plugin_context.cpp.o
Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/generic_proxy.cpp.o
[ 46%] Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/plugin_descriptor.cpp.o
[ 53%] [ 61%] Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/plugin_provider.cpp.o
Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/recursive_plugin_provider.cpp.o
[ 69%] Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/settings.cpp.o
[ 76%] Building CXX object src/qt_gui_cpp/CMakeFiles/qt_gui_cpp.dir/__/__/include/qt_gui_cpp/moc_plugin_bridge.cxx.o
Linking CXX shared library /Users/william/ros_catkin_ws/devel_isolated/qt_gui_cpp/lib/libqt_gui_cpp.dylib
[ 76%] Built target qt_gui_cpp
Scanning dependencies of target libqt_gui_cpp_sip
[ 84%] Running SIP generator for qt_gui_cpp_sip Python bindings...
sip: Deprecation warning: qt_gui_cpp.sip:1: %Module version number should be specified using the 'version' argument
[ 92%] Compiling generated code for qt_gui_cpp_sip Python bindings...
In file included from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader_core.h:39,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader_register_macro.h:33,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader.h:39,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/multi_library_class_loader.h:33,
                 from /Users/william/ros_catkin_ws/install_isolated/include/pluginlib/class_loader.h:33,
                 from /Users/william/ros_catkin_ws/src/qt_gui_cpp/src/qt_gui_cpp_sip/../../include/qt_gui_cpp/ros_pluginlib_plugin_provider.h:43,
                 from /Users/william/ros_catkin_ws/src/qt_gui_cpp/src/qt_gui_cpp_sip/../../include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugins.h:37,
                 from ros_pluginlib_plugin_provider_for_plugins.sip:9:
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h: In constructor ‘class_loader::class_loader_private::MetaObject<C, B>::MetaObject(const std::string&, const std::string&)’:
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h:135: error: object missing in reference to ‘class_loader::class_loader_private::AbstractMetaObjectBase::typeid_base_class_name_’
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h:193: error: from this location
In file included from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader_core.h:39,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader_register_macro.h:33,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader.h:39,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/multi_library_class_loader.h:33,
                 from /Users/william/ros_catkin_ws/install_isolated/include/pluginlib/class_loader.h:33,
                 from /Users/william/ros_catkin_ws/src/qt_gui_cpp/src/qt_gui_cpp_sip/../../include/qt_gui_cpp/ros_pluginlib_plugin_provider.h:43,
                 from /Users/william/ros_catkin_ws/src/qt_gui_cpp/src/qt_gui_cpp_sip/../../include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugin_providers.h:37,
                 from ros_pluginlib_plugin_provider_for_plugin_providers.sip:9:
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h: In constructor ‘class_loader::class_loader_private::MetaObject<C, B>::MetaObject(const std::string&, const std::string&)’:
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h:135: error: object missing in reference to ‘class_loader::class_loader_private::AbstractMetaObjectBase::typeid_base_class_name_’
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h:193: error: from this location
In file included from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader_core.h:39,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader_register_macro.h:33,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/class_loader.h:39,
                 from /Users/william/ros_catkin_ws/install_isolated/include/class_loader/multi_library_class_loader.h:33,
                 from /Users/william/ros_catkin_ws/install_isolated/include/pluginlib/class_loader.h:33,
                 from /Users/william/ros_catkin_ws/src/qt_gui_cpp/src/qt_gui_cpp_sip/../../include/qt_gui_cpp/ros_pluginlib_plugin_provider.h:43,
                 from /Users/william/ros_catkin_ws/src/qt_gui_cpp/src/qt_gui_cpp_sip/../../include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugin_providers.h:37,
                 from /Users/william/ros_catkin_ws/src/qt_gui_cpp/src/qt_gui_cpp_sip/../../include/qt_gui_cpp/recursive_plugin_provider.h:37,
                 from recursive_plugin_provider.sip:8:
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h: In constructor ‘class_loader::class_loader_private::MetaObject<C, B>::MetaObject(const std::string&, const std::string&)’:
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h:135: error: object missing in reference to ‘class_loader::class_loader_private::AbstractMetaObjectBase::typeid_base_class_name_’
/Users/william/ros_catkin_ws/install_isolated/include/class_loader/meta_object.h:193: error: from this location
make[3]: *** [siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: *** [siplibqt_gui_cpp_sipqt_gui_cppRecursivePluginProvider.o] Error 1
make[3]: *** [siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.o] Error 1
make[2]: *** [/Users/william/ros_catkin_ws/devel_isolated/qt_gui_cpp/lib/python2.7/site-packages/qt_gui_cpp/libqt_gui_cpp_sip.dylib] Error 2
make[1]: *** [src/qt_gui_cpp_sip/CMakeFiles/libqt_gui_cpp_sip.dir/all] Error 2
make: *** [all] Error 2

<== Failed to process package 'qt_gui_cpp': 
  Command '/Users/william/ros_catkin_ws/install_isolated/env_cached.sh make -j4' returned non-zero exit status 2
Command failed, exiting.
```

I have a patch as a pull request, I moved the line in question up to a parent class which seems to be a more appropriate place for it.
