### PR TITLE
Poco detection is too confident when seeing /usr/include/Foundation

### DIFF
--- a/cmake/FindPoco.cmake
+++ b/cmake/FindPoco.cmake
@@ -100,7 +100,7 @@ SET(SUFFIX_FOR_LIBRARY_PATH
 #
 # Look for an installation.
 #
-FIND_PATH(Poco_INCLUDE_DIR NAMES Foundation/include/Poco/AbstractCache.h PATH_SUFFIXES ${SUFFIX_FOR_INCLUDE_PATH} PATHS
+FIND_PATH(Poco_INCLUDE_DIR NAMES Foundation/include/Poco/SharedLibrary.h PATH_SUFFIXES ${SUFFIX_FOR_INCLUDE_PATH} PATHS
 
 # Look in other places.
   ${POCO_DIR_SEARCH}
@@ -121,7 +121,7 @@ SET(Poco_FOUND 0)
 
 # Now try to get the include and library path.
 IF(Poco_INCLUDE_DIR)
-  IF(EXISTS "${Poco_INCLUDE_DIR}/Foundation/include/Poco/AbstractCache.h")
+  IF(EXISTS "${Poco_INCLUDE_DIR}/Foundation/include/Poco/SharedLibrary.h")
     SET(Poco_INCLUDE_DIRS
       ${Poco_INCLUDE_DIR}/CppUnit/include
       ${Poco_INCLUDE_DIR}/Foundation/include

--- a/cmake/FindPoco.cmake
+++ b/cmake/FindPoco.cmake
@@ -121,7 +121,7 @@ SET(Poco_FOUND 0)
 
 # Now try to get the include and library path.
 IF(Poco_INCLUDE_DIR)
-  IF(EXISTS "${Poco_INCLUDE_DIR}/Foundation")
+  IF(EXISTS "${Poco_INCLUDE_DIR}/Foundation/include/Poco/AbstractCache.h")
     SET(Poco_INCLUDE_DIRS
       ${Poco_INCLUDE_DIR}/CppUnit/include
       ${Poco_INCLUDE_DIR}/Foundation/include

--- a/cmake/PocoConfig.cmake
+++ b/cmake/PocoConfig.cmake
@@ -100,7 +100,7 @@ SET(SUFFIX_FOR_LIBRARY_PATH
 #
 # Look for an installation.
 #
-FIND_PATH(Poco_INCLUDE_DIR NAMES Foundation/include/Poco/AbstractCache.h PATH_SUFFIXES ${SUFFIX_FOR_INCLUDE_PATH} PATHS
+FIND_PATH(Poco_INCLUDE_DIR NAMES Foundation/include/Poco/SharedLibrary.h PATH_SUFFIXES ${SUFFIX_FOR_INCLUDE_PATH} PATHS
 
 # Look in other places.
   ${POCO_DIR_SEARCH}
@@ -121,7 +121,7 @@ SET(Poco_FOUND 0)
 
 # Now try to get the include and library path.
 IF(Poco_INCLUDE_DIR)
-  IF(EXISTS "${Poco_INCLUDE_DIR}/Foundation/include/Poco/AbstractCache.h")
+  IF(EXISTS "${Poco_INCLUDE_DIR}/Foundation/include/Poco/SharedLibrary.h")
     SET(Poco_INCLUDE_DIRS
       ${Poco_INCLUDE_DIR}/CppUnit/include
       ${Poco_INCLUDE_DIR}/Foundation/include

--- a/cmake/PocoConfig.cmake
+++ b/cmake/PocoConfig.cmake
@@ -121,7 +121,7 @@ SET(Poco_FOUND 0)
 
 # Now try to get the include and library path.
 IF(Poco_INCLUDE_DIR)
-  IF(EXISTS "${Poco_INCLUDE_DIR}/Foundation")
+  IF(EXISTS "${Poco_INCLUDE_DIR}/Foundation/include/Poco/AbstractCache.h")
     SET(Poco_INCLUDE_DIRS
       ${Poco_INCLUDE_DIR}/CppUnit/include
       ${Poco_INCLUDE_DIR}/Foundation/include


### PR DESCRIPTION
That folder is also provided by gnustep-base. Ubuntu encapsulates the gnustep
headers in a GNUstep folder, however the project itself installs to
/usr/include/Foundation and other linux distributions(Archlinux, Gentoo,
Lunar-Linux, ...) respect this.
