### PR TITLE
using CATKIN_ENABLE_TESTING to optionally configure tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,4 +32,6 @@ install(TARGETS ${PROJECT_NAME}
 install(DIRECTORY include/class_loader/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
+if(CATKIN_ENABLE_TESTING)
 add_subdirectory(test)
+endif()


### PR DESCRIPTION
Since ff60599b8077b86a6d75d510da72e69899d16008 in the catkin
repository, catkin provides means to optionally configure tests.
This commit adjusts the CMakeLists.txt to opt-in the tests.

This commit is currently needed for cross-compiling class-loader
(without tests) in the meta-ros project (github.com/bmwcarit/meta-ros)
without requiring gtest. Details are found at
https://github.com/bmwcarit/meta-ros/issues/86.

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
