### PR TITLE
Simultaneous library load causes persistent plugin load failure

### DIFF
--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -56,6 +56,13 @@ boost::recursive_mutex& getPluginBaseToFactoryMapMapMutex()
   return m;
 }
 
+boost::recursive_mutex& getLibraryLoaderMutex()
+/*****************************************************************************/
+{
+  static boost::recursive_mutex m;
+  return m;
+}
+
 BaseToFactoryMapMap& getGlobalPluginBaseToFactoryMapMap()
 /*****************************************************************************/
 {
@@ -427,33 +434,38 @@ void loadLibrary(const std::string& library_path, ClassLoader* loader)
   
   Poco::SharedLibrary* library_handle = NULL;
 
-  try
   {
-    setCurrentlyActiveClassLoader(loader);
-    setCurrentlyLoadingLibraryName(library_path);
-    library_handle = new Poco::SharedLibrary(library_path);
-  }
-  catch(const Poco::LibraryLoadException& e)
-  {
+    boost::recursive_mutex::scoped_lock libload_lock(getLibraryLoaderMutex());
+
+    try
+    {
+      setCurrentlyActiveClassLoader(loader);
+      setCurrentlyLoadingLibraryName(library_path);
+      library_handle = new Poco::SharedLibrary(library_path);
+    }
+    catch(const Poco::LibraryLoadException& e)
+    {
+      setCurrentlyLoadingLibraryName("");
+      setCurrentlyActiveClassLoader(NULL);
+      throw(class_loader::LibraryLoadException("Could not load library (Poco exception = " + std::string(e.message()) + ")"));
+    }
+    catch(const Poco::LibraryAlreadyLoadedException& e)
+    {
+      setCurrentlyLoadingLibraryName("");
+      setCurrentlyActiveClassLoader(NULL);
+      throw(class_loader::LibraryLoadException("Library already loaded (Poco exception = " + std::string(e.message()) + ")"));
+    }
+    catch(const Poco::NotFoundException& e)
+    {
+      setCurrentlyLoadingLibraryName("");
+      setCurrentlyActiveClassLoader(NULL);
+      throw(class_loader::LibraryLoadException("Library not found (Poco exception = " + std::string(e.message()) + ")"));
+    }
+
     setCurrentlyLoadingLibraryName("");
     setCurrentlyActiveClassLoader(NULL);
-    throw(class_loader::LibraryLoadException("Could not load library (Poco exception = " + std::string(e.message()) + ")"));
-  }
-  catch(const Poco::LibraryAlreadyLoadedException& e)
-  {
-    setCurrentlyLoadingLibraryName("");
-    setCurrentlyActiveClassLoader(NULL);
-    throw(class_loader::LibraryLoadException("Library already loaded (Poco exception = " + std::string(e.message()) + ")"));
-  }
-  catch(const Poco::NotFoundException& e)
-  {
-    setCurrentlyLoadingLibraryName("");
-    setCurrentlyActiveClassLoader(NULL);
-    throw(class_loader::LibraryLoadException("Library not found (Poco exception = " + std::string(e.message()) + ")"));
   }
 
-  setCurrentlyLoadingLibraryName("");
-  setCurrentlyActiveClassLoader(NULL);
   assert(library_handle != NULL);
   logDebug("class_loader::class_loader_private: Successfully loaded library %s into memory (Poco::SharedLibrary handle = %p).", library_path.c_str(), library_handle);
 


### PR DESCRIPTION
I've been hitting this issue for about a year now, and I figured that it was serious enough that it would be caught and fixed quickly, but its still in the latest class_loader from groovy-devel.

The problem presents itself sporadically when loading nodelets with a message indicating that no factory function exists for the target class. When I trace the problem, it appears to happen whenever a library load is attempted while another library load is in progress. From what I can tell:

Plugin A enters https://github.com/ros/class_loader/blob/groovy-devel/src/class_loader_core.cpp#L432

Plugin B enters https://github.com/ros/class_loader/blob/groovy-devel/src/class_loader_core.cpp#L432 before plugin A reaches https://github.com/ros/class_loader/blob/groovy-devel/src/class_loader_core.cpp#L455

Plugin A then enters https://github.com/ros/class_loader/blob/groovy-devel/src/class_loader_core.cpp#L464 even though it is the initial load, and thus never registers any Meta Objects, which causes all future attempts to load the plugin to fail while this instance of the class_loader_private is in memory.

I created a static mutex in the same way the others are made in this file, and turned https://github.com/ros/class_loader/blob/groovy-devel/src/class_loader_core.cpp#L430-L457 into a critical section of code. This seems to prevent the scenario from occurring.

I think the easiest way to trick this into happening is to make the library load take a long time (ie slow hard disk), and try to load two plugins from different libraries at the same time. This has been quite difficult to reproduce. I think the reason it happens on our lab machines is that their ROS environments are NFS mounted, and so there is a little bit of network latency associated with file access, but I can't be sure.

Am I crazy? Is this a poor approach to solving this problem?

Thanks!

--scott
