### PR TITLE
Do not use shared libraries on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(${PROJECT_NAME}_SRCS
   src/meta_object.cpp
   src/multi_library_class_loader.cpp
 )
-add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SRCS})
+add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS})
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${console_bridge_LIBRARIES} ${Poco_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
This is needed for cross-compiling ROS to run on Android devices as we need to use static libraries.

Is there a specific reason why this lib needs to be hard-coded as shared? I've added the if clause to avoid breaking something else but, as catkin_make's default behavior is to build shared libraries, this seems redundant and maybe we can omit it, or is there something else I'm not considering?

Thanks!
