### PR TITLE
Depend on boost

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,10 +12,12 @@
  
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
+  <build_depend>boost</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
   <build_depend>libpoco-dev</build_depend>
   <build_depend version_gte="0.3.3">cmake_modules</build_depend>
 
+  <run_depend>boost</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
   <run_depend>libpoco-dev</run_depend>
 </package>


### PR DESCRIPTION
Boost is clearly needed by this package [1], so it should depend on it. This probably came to light because an upstream package no longer depends on boost, or the dependencies of this package changed. In any case, it should be added.

Example of build failure: https://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-class-loader_binaryrpm_21_x86_64/2/console

Associated rosdep key: https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L277-L324

Thanks,

--scott

[1] https://github.com/ros/class_loader/blob/indigo-devel/CMakeLists.txt#L4
