### PR TITLE
Minor fixes related ros-independed usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if(CATKIN_ENABLE_TESTING)
   add_subdirectory(test)
 endif()
 
-if(!${catkin_FOUND})
+if(NOT ${catkin_FOUND})
   set(TARGET_NAME ${PROJECT_NAME})
   set(PKGCONFIG_LIBS 
     ${Boost_LIBRARIES} 


### PR DESCRIPTION
This fixes the installation of the pkg-config file, and make it able to select ba adding cmake-options to build a shared version
