### PR TITLE
Add helper functions for creating OS specific library names

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ install:
   - cd src
   - python -c "import shutil; shutil.copytree('../..', './class_loader', ignore=shutil.ignore_patterns('build'))"
   - git clone https://github.com/ros/console_bridge.git -b ros2
-  - git clone https://github.com/pocoproject/poco.git -b poco-1.6.1-release
+  - git clone --depth 1 https://github.com/pocoproject/poco.git -b poco-1.6.1-release
   - mkdir ament
   - cd ament
   - git clone https://github.com/ament/ament_cmake.git
@@ -35,22 +35,6 @@ install:
 build_script:
   - cd build
   - |
-    python -u src\ament\ament_tools\scripts\ament.py build \
-      --build-tests \
-      --cmake-args \
-      -DENABLE_XML:BOOL=OFF \
-      -DENABLE_JSON:BOOL=OFF \
-      -DENABLE_MONGODB:BOOL=OFF \
-      -DENABLE_UTIL:BOOL=OFF \
-      -DENABLE_NET:BOOL=OFF \
-      -DENABLE_NETSSL:BOOL=OFF \
-      -DENABLE_CRYPTO:BOOL=OFF \
-      -DENABLE_DATA:BOOL=OFF \
-      -DENABLE_DATA_SQLITE:BOOL=OFF \
-      -DENABLE_DATA_MYSQL:BOOL=OFF \
-      -DENABLE_DATA_ODBC:BOOL=OFF \
-      -DENABLE_ZIP:BOOL=OFF \
-      -DENABLE_PAGECOMPILER:BOOL=OFF \
-      -DENABLE_PAGECOMPILER_FILE2PAGE:BOOL=OFF
+    python -u src\ament\ament_tools\scripts\ament.py build --build-tests --cmake-args -DENABLE_XML:BOOL=OFF -DENABLE_JSON:BOOL=OFF -DENABLE_MONGODB:BOOL=OFF -DENABLE_UTIL:BOOL=OFF -DENABLE_NET:BOOL=OFF -DENABLE_NETSSL:BOOL=OFF -DENABLE_CRYPTO:BOOL=OFF -DENABLE_DATA:BOOL=OFF -DENABLE_DATA_SQLITE:BOOL=OFF -DENABLE_DATA_MYSQL:BOOL=OFF -DENABLE_DATA_ODBC:BOOL=OFF -DENABLE_ZIP:BOOL=OFF -DENABLE_PAGECOMPILER:BOOL=OFF -DENABLE_PAGECOMPILER_FILE2PAGE:BOOL=OFF
   - python -u src\ament\ament_tools\scripts\ament.py test --skip-build --skip-install --only class_loader
 deploy: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,6 +34,23 @@ install:
   - set "PATH=%PATH%;C:\Python34"
 build_script:
   - cd build
-  - python -u src\ament\ament_tools\scripts\ament.py build --build-tests
+  - |
+    python -u src\ament\ament_tools\scripts\ament.py build \
+      --build-tests \
+      --cmake-args \
+      -DENABLE_XML:BOOL=OFF \
+      -DENABLE_JSON:BOOL=OFF \
+      -DENABLE_MONGODB:BOOL=OFF \
+      -DENABLE_UTIL:BOOL=OFF \
+      -DENABLE_NET:BOOL=OFF \
+      -DENABLE_NETSSL:BOOL=OFF \
+      -DENABLE_CRYPTO:BOOL=OFF \
+      -DENABLE_DATA:BOOL=OFF \
+      -DENABLE_DATA_SQLITE:BOOL=OFF \
+      -DENABLE_DATA_MYSQL:BOOL=OFF \
+      -DENABLE_DATA_ODBC:BOOL=OFF \
+      -DENABLE_ZIP:BOOL=OFF \
+      -DENABLE_PAGECOMPILER:BOOL=OFF \
+      -DENABLE_PAGECOMPILER_FILE2PAGE:BOOL=OFF
   - python -u src\ament\ament_tools\scripts\ament.py test --skip-build --skip-install --only class_loader
 deploy: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,3 +38,4 @@ build_script:
     python -u src\ament\ament_tools\scripts\ament.py build --build-tests --cmake-args -DENABLE_XML:BOOL=OFF -DENABLE_JSON:BOOL=OFF -DENABLE_MONGODB:BOOL=OFF -DENABLE_UTIL:BOOL=OFF -DENABLE_NET:BOOL=OFF -DENABLE_NETSSL:BOOL=OFF -DENABLE_CRYPTO:BOOL=OFF -DENABLE_DATA:BOOL=OFF -DENABLE_DATA_SQLITE:BOOL=OFF -DENABLE_DATA_MYSQL:BOOL=OFF -DENABLE_DATA_ODBC:BOOL=OFF -DENABLE_ZIP:BOOL=OFF -DENABLE_PAGECOMPILER:BOOL=OFF -DENABLE_PAGECOMPILER_FILE2PAGE:BOOL=OFF
   - python -u src\ament\ament_tools\scripts\ament.py test --skip-build --skip-install --only class_loader
 deploy: off
+test: off

--- a/include/class_loader/class_loader.h
+++ b/include/class_loader/class_loader.h
@@ -47,10 +47,25 @@ namespace class_loader
 {
 
 /**
-* returns runtime library extension for native os
-*/
+ * returns the default library prefix for the native os
+ */
+CLASS_LOADER_PUBLIC
+std::string systemLibraryPrefix();
+
+/**
+ * returns runtime library extension for native os
+ */
 CLASS_LOADER_PUBLIC
 std::string systemLibrarySuffix();
+
+/**
+ * returns a platform specific version of a basic library name
+ *
+ * On *nix platforms the library name is prefixed with `lib`.
+ * On all platforms the output of class_loader::systemLibrarySuffix() is appended.
+ */
+CLASS_LOADER_PUBLIC
+std::string systemLibraryFormat(const std::string & library_name);
 
 /**
  * @class ClassLoader

--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -49,7 +49,13 @@ std::string systemLibraryPrefix()
 
 std::string systemLibrarySuffix()
 {
+#if !defined(WIN32)
   return Poco::SharedLibrary::suffix();
+#else
+  // Return just .dll , as Poco::SharedLibrary::suffix() will return d.dll in debug mode.
+  // This isn't common for our usecase (instead debug libraries are placed in a `Debug` folder).
+  return ".dll";
+#endif
 }
 
 std::string systemLibraryFormat(const std::string & library_name)

--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -39,9 +39,22 @@ bool ClassLoader::hasUnmanagedInstanceBeenCreated()
   return ClassLoader::has_unmananged_instance_been_created_;
 }
 
+std::string systemLibraryPrefix()
+{
+#if !defined(WIN32)
+  return "lib";
+#endif
+  return "";
+}
+
 std::string systemLibrarySuffix()
 {
   return Poco::SharedLibrary::suffix();
+}
+
+std::string systemLibraryFormat(const std::string & library_name)
+{
+  return systemLibraryPrefix() + library_name + systemLibrarySuffix();
 }
 
 ClassLoader::ClassLoader(const std::string & library_path, bool ondemand_load_unload)

--- a/test/fviz_case_study/fviz_default_plugin.cpp
+++ b/test/fviz_case_study/fviz_default_plugin.cpp
@@ -6,6 +6,7 @@
 class Bar : public FvizPluginBase
 {
 public:
+  virtual ~Bar() = default;
   void speak()
   {
     foo("from plugin Bar");
@@ -15,6 +16,7 @@ public:
 class Baz : public FvizPluginBase
 {
 public:
+  virtual ~Baz() = default;
   void speak()
   {
     foo("from plugin Baz");

--- a/test/fviz_case_study/fviz_main.cpp
+++ b/test/fviz_case_study/fviz_main.cpp
@@ -6,11 +6,7 @@
 #include "fviz.h"
 #include "fviz_plugin_base.h"
 
-#if defined(WIN32)
-std::string name = "class_loader_Test_FvizDefaultPlugin";
-#else
-std::string name = "libclass_loader_Test_FvizDefaultPlugin" + class_loader::systemLibrarySuffix();
-#endif
+std::string name = class_loader::systemLibraryFormat("class_loader_Test_FvizDefaultPlugin");
 
 int main(void)
 {

--- a/test/fviz_case_study/fviz_plugin_base.h
+++ b/test/fviz_case_study/fviz_plugin_base.h
@@ -4,6 +4,7 @@
 class FvizPluginBase
 {
 public:
+  virtual ~FvizPluginBase() {}
   virtual void speak() = 0;
 };
 

--- a/test/fviz_case_study/fviz_test.cpp
+++ b/test/fviz_case_study/fviz_test.cpp
@@ -5,11 +5,7 @@
 #include "fviz.h"
 #include "fviz_plugin_base.h"
 
-#if defined(WIN32)
-std::string name = "class_loader_Test_FvizDefaultPlugin";
-#else
-std::string name = "libclass_loader_Test_FvizDefaultPlugin" + class_loader::systemLibrarySuffix();
-#endif
+std::string name = class_loader::systemLibraryFormat("class_loader_Test_FvizDefaultPlugin");
 
 TEST(FvizTest, basic_test)
 {

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -8,13 +8,8 @@
 
 #include "base.h"
 
-#if defined(WIN32)
-const std::string LIBRARY_1 = "class_loader_TestPlugins1";
-const std::string LIBRARY_2 = "class_loader_TestPlugins2";
-#else
-const std::string LIBRARY_1 = "libclass_loader_TestPlugins1" + class_loader::systemLibrarySuffix();
-const std::string LIBRARY_2 = "libclass_loader_TestPlugins2" + class_loader::systemLibrarySuffix();
-#endif
+const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");
+const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");
 
 TEST(ClassLoaderTest, basicLoad)
 {


### PR DESCRIPTION
This won't always work (depending on how people build their plugin libraries), but it should allow for less code in the default case.
