### PR TITLE
fix on demand unloading

### DIFF
--- a/include/class_loader/multi_library_class_loader.h
+++ b/include/class_loader/multi_library_class_loader.h
@@ -73,6 +73,8 @@ class MultiLibraryClassLoader
       for(unsigned int c = 0; c < active_loaders.size(); c++)
       {
         ClassLoader* current = active_loaders.at(c);
+        if (!current->isLibraryLoaded())
+          current->loadLibrary();
         if(current->isClassAvailable<Base>(class_name))
           return(current->createInstance<Base>(class_name));
       }
@@ -113,6 +115,8 @@ class MultiLibraryClassLoader
       for(unsigned int c = 0; c < active_loaders.size(); c++)
       {
         ClassLoader* current = active_loaders.at(c);
+        if (!current->isLibraryLoaded())
+          current->loadLibrary();
         if(current->isClassAvailable<Base>(class_name))
           return(current->createUnmanagedInstance<Base>(class_name));
       }

--- a/src/multi_library_class_loader.cpp
+++ b/src/multi_library_class_loader.cpp
@@ -39,7 +39,10 @@ enable_ondemand_loadunload_(enable_ondemand_loadunload)
 
 MultiLibraryClassLoader::~MultiLibraryClassLoader()
 {
-  shutdownAllClassLoaders();
+  if (!isOnDemandLoadUnloadEnabled())
+    shutdownAllClassLoaders(); // don't unload libs to avoid SEVERE WARNING
+  // TODO: free ClassLoaders in active_class_loaders_
+  // However, we still need them in on-demand-load-unload mode. Otherwise we risk seg-faults.
 }
 
 std::vector<std::string> MultiLibraryClassLoader::getRegisteredLibraries()

--- a/src/multi_library_class_loader.cpp
+++ b/src/multi_library_class_loader.cpp
@@ -39,10 +39,7 @@ enable_ondemand_loadunload_(enable_ondemand_loadunload)
 
 MultiLibraryClassLoader::~MultiLibraryClassLoader()
 {
-  if (!isOnDemandLoadUnloadEnabled())
-    shutdownAllClassLoaders(); // don't unload libs to avoid SEVERE WARNING
-  // TODO: free ClassLoaders in active_class_loaders_
-  // However, we still need them in on-demand-load-unload mode. Otherwise we risk seg-faults.
+  shutdownAllClassLoaders();
 }
 
 std::vector<std::string> MultiLibraryClassLoader::getRegisteredLibraries()

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -326,6 +326,10 @@ TEST(MultiClassLoaderTest, lazyLoad)
 {
   testMultiClassLoader(true);
 }
+TEST(MultiClassLoaderTest, lazyLoadSecondTime)
+{
+  testMultiClassLoader(true);
+}
 TEST(MultiClassLoaderTest, nonLazyLoad)
 {
   testMultiClassLoader(false);

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -2,6 +2,7 @@
 #include <boost/bind.hpp>
 #include <iostream>
 #include <class_loader/class_loader.h>
+#include <class_loader/multi_library_class_loader.h>
 #include "base.h"
 #include <gtest/gtest.h>
 
@@ -297,8 +298,65 @@ TEST(ClassLoaderTest, loadRefCountingLazy)
   FAIL() << "Did not throw exception as expected.\n";
 }
 
+
 /*****************************************************************************/
 
+void testMultiClassLoader(bool lazy)
+{
+  try
+  {
+    class_loader::MultiLibraryClassLoader loader(lazy);
+    loader.loadLibrary(LIBRARY_1);
+    loader.loadLibrary(LIBRARY_2);
+    for (int i=0; i < 2; ++i) {
+      loader.createInstance<Base>("Cat")->saySomething();
+      loader.createInstance<Base>("Dog")->saySomething();
+      loader.createInstance<Base>("Robot")->saySomething();
+    }
+  }
+  catch(class_loader::ClassLoaderException& e)
+  {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+
+  SUCCEED();
+}
+
+TEST(MultiClassLoaderTest, lazyLoad)
+{
+  testMultiClassLoader(true);
+}
+TEST(MultiClassLoaderTest, nonLazyLoad)
+{
+  testMultiClassLoader(false);
+}
+TEST(MultiClassLoaderTest, noWarningOnLazyLoad)
+{
+  try
+  {
+    boost::shared_ptr<Base> cat, dog, rob;
+    {
+      class_loader::MultiLibraryClassLoader loader(true);
+      loader.loadLibrary(LIBRARY_1);
+      loader.loadLibrary(LIBRARY_2);
+
+      cat = loader.createInstance<Base>("Cat");
+      dog = loader.createInstance<Base>("Dog");
+      rob = loader.createInstance<Base>("Robot");
+    }
+    cat->saySomething();
+    dog->saySomething();
+    rob->saySomething();
+  }
+  catch(class_loader::ClassLoaderException& e)
+  {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+
+  SUCCEED();
+}
+
+/*****************************************************************************/
 
 // Run all the tests that were declared with TEST()
 int main(int argc, char **argv){


### PR DESCRIPTION
On-demand-unloading was broken because:
- loading always needs to be done, otherwise the classes from the lib cannot be known
- `MultiLibraryClassLoader` shouldn't unload its libs when on-demand-unloading is enabled

This relates to https://github.com/ros/pluginlib/pull/37 and fixes https://github.com/ros/pluginlib/issues/38.
