### PR TITLE
add missing exec depend on poco_vendor

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
 
   <exec_depend>console_bridge</exec_depend>
   <exec_depend>libpoco-dev</exec_depend>
+  <exec_depend>poco_vendor</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 


### PR DESCRIPTION
Otherwise the exported environment from `poco_vendor` is not available to downstream packages using `class_loader`.