### PR TITLE
Export Poco libraries

### DIFF
--- a/class_loader-extras.cmake
+++ b/class_loader-extras.cmake
@@ -1,1 +1,5 @@
 include("${class_loader_DIR}/class_loader_hide_library_symbols.cmake")
+
+find_package(poco_vendor REQUIRED)
+find_package(Poco REQUIRED COMPONENTS Foundation)
+list(APPEND class_loader_LIBRARIES ${Poco_LIBRARIES})


### PR DESCRIPTION
While crosscompiling the `rclcpp` examples, I found out that the composition one all missed the Poco symbols, this change fixes that.

Edit: updated to mention the composition examples