### PR TITLE
Replace deprecated macro logInform

### DIFF
--- a/include/class_loader/class_loader_register_macro.h
+++ b/include/class_loader/class_loader_register_macro.h
@@ -43,7 +43,7 @@ namespace \
     ProxyExec##UniqueID() \
     { \
       if(std::string(Message)!="")\
-        logInform("%s", Message);\
+        CONSOLE_BRIDGE_logInform("%s", Message);\
       class_loader::class_loader_private::registerPlugin<_derived, _base>(#Derived, #Base); \
     }\
   };\


### PR DESCRIPTION
Since 2015 `logInform` is deprecated (see https://github.com/ros/console_bridge/commit/4c529c62e606e3e6fdb9bca2468ad397f2c011ae). So use the new name to prevent clang from showing lots of warnings like

```
/home/[snip]:123:1: warning: 'log_deprecated' is deprecated [-Wdeprecated-declarations]
PLUGINLIB_EXPORT_CLASS(MyNodelet, nodelet::Nodelet)
^
/opt/ros/kinetic/include/pluginlib/class_list_macros.h:67:3: note: expanded from macro 'PLUGINLIB_EXPORT_CLASS'
  CLASS_LOADER_REGISTER_CLASS(class_type, base_class_type);
  ^
/opt/ros/kinetic/include/class_loader/class_loader_register_macro.h:65:53: note: expanded from macro 'CLASS_LOADER_REGISTER_CLASS'
#define CLASS_LOADER_REGISTER_CLASS(Derived, Base)  CLASS_LOADER_REGISTER_CLASS_WITH_MESSAGE(Derived, Base, "")
                                                    ^
/opt/ros/kinetic/include/class_loader/class_loader_register_macro.h:59:75: note: expanded from macro 'CLASS_LOADER_REGISTER_CLASS_WITH_MESSAGE'
#define CLASS_LOADER_REGISTER_CLASS_WITH_MESSAGE(Derived, Base, Message)  CLASS_LOADER_REGISTER_CLASS_INTERNAL_HOP1_WITH_MESSAGE(Derived, Base, __COUNTER__, Message)
                                                                          ^
/opt/ros/kinetic/include/class_loader/class_loader_register_macro.h:53:98: note: expanded from macro 'CLASS_LOADER_REGISTER_CLASS_INTERNAL_HOP1_WITH_MESSAGE'
#define CLASS_LOADER_REGISTER_CLASS_INTERNAL_HOP1_WITH_MESSAGE(Derived, Base, UniqueID, Message) CLASS_LOADER_REGISTER_CLASS_INTERNAL_WITH_MESSAGE(Derived, Base, UniqueID, Message)
                                                                                                 ^
/opt/ros/kinetic/include/class_loader/class_loader_register_macro.h:46:9: note: expanded from macro 'CLASS_LOADER_REGISTER_CLASS_INTERNAL_WITH_MESSAGE'
        logInform("%s", Message);\
        ^
/usr/include/console_bridge/console.h:96:19: note: expanded from macro 'logInform'
  console_bridge::log_deprecated(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
                  ^
/usr/include/console_bridge/console.h:202:54: note: 'log_deprecated' has been explicitly marked deprecated here
CONSOLE_BRIDGE_DEPRECATED CONSOLE_BRIDGE_DLLAPI void log_deprecated(const char *file, int line, LogLevel level, const char* m, ...);
```