### PR TITLE
include functional to prevent warnings on gcc7.x

### DIFF
--- a/include/class_loader/class_loader.h
+++ b/include/class_loader/class_loader.h
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>


### PR DESCRIPTION
Fixes #47 , thanks @mjbogusz for reporting it.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2851)](http://ci.ros2.org/job/ci_linux/2851/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=355)](http://ci.ros2.org/job/ci_linux-aarch64/355/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2307)](http://ci.ros2.org/job/ci_osx/2307/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2990)](http://ci.ros2.org/job/ci_windows/2990/)

