### PR TITLE
Fix memory leak and build warning 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(${PROJECT_NAME}_HDRS
   include/class_loader/class_loader_core.h
   include/class_loader/class_loader_exceptions.h
   include/class_loader/class_loader.h
+  include/class_loader/console_bridge_compatibility.h
   include/class_loader/class_loader_register_macro.h
   include/class_loader/meta_object.h
   include/class_loader/multi_library_class_loader.h

--- a/include/class_loader/class_loader.h
+++ b/include/class_loader/class_loader.h
@@ -38,6 +38,7 @@
 #include <console_bridge/console.h>
 #include "class_loader/class_loader_register_macro.h"
 #include "class_loader/class_loader_core.h"
+#include "class_loader/console_bridge_compatibility.h"
 
 #if __cplusplus >= 201103L
 #  include<memory>
@@ -200,7 +201,7 @@ class ClassLoader
     template <class Base>
     void onPluginDeletion(Base* obj)
     {
-      logDebug("class_loader::ClassLoader: Calling onPluginDeletion() for obj ptr = %p.\n", obj);
+      CONSOLE_BRIDGE_logDebug("class_loader::ClassLoader: Calling onPluginDeletion() for obj ptr = %p.\n", obj);
       if(obj)
       {
         boost::recursive_mutex::scoped_lock lock(plugin_ref_count_mutex_);
@@ -212,7 +213,7 @@ class ClassLoader
           if(!ClassLoader::hasUnmanagedInstanceBeenCreated())
             unloadLibraryInternal(false);
           else
-            logWarn("class_loader::ClassLoader: Cannot unload library %s even though last shared pointer went out of scope. This is because createUnmanagedInstance was used within the scope of this process, perhaps by a different ClassLoader. Library will NOT be closed.", getLibraryPath().c_str());
+            CONSOLE_BRIDGE_logWarn("class_loader::ClassLoader: Cannot unload library %s even though last shared pointer went out of scope. This is because createUnmanagedInstance was used within the scope of this process, perhaps by a different ClassLoader. Library will NOT be closed.", getLibraryPath().c_str());
         }
       }
     }
@@ -234,7 +235,7 @@ class ClassLoader
         has_unmananged_instance_been_created_ = true;
 
       if (managed && ClassLoader::hasUnmanagedInstanceBeenCreated() && isOnDemandLoadUnloadEnabled())
-        logInform("class_loader::ClassLoader: An attempt is being made to create a managed plugin instance (i.e. boost::shared_ptr), however an unmanaged instance was created within this process address space. This means libraries for the managed instances will not be shutdown automatically on final plugin destruction if on demand (lazy) loading/unloading mode is used.");
+        CONSOLE_BRIDGE_logInform("class_loader::ClassLoader: An attempt is being made to create a managed plugin instance (i.e. boost::shared_ptr), however an unmanaged instance was created within this process address space. This means libraries for the managed instances will not be shutdown automatically on final plugin destruction if on demand (lazy) loading/unloading mode is used.");
 
       if (!isLibraryLoaded())
         loadLibrary();

--- a/include/class_loader/class_loader_core.h
+++ b/include/class_loader/class_loader_core.h
@@ -159,11 +159,11 @@ void registerPlugin(const std::string& class_name, const std::string& base_class
   //Note: This function will be automatically invoked when a dlopen() call
   //opens a library. Normally it will happen within the scope of loadLibrary(),
   //but that may not be guaranteed.
-  logDebug("class_loader.class_loader_private: Registering plugin factory for class = %s, ClassLoader* = %p and library name %s.", class_name.c_str(), getCurrentlyActiveClassLoader(), getCurrentlyLoadingLibraryName().c_str());
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Registering plugin factory for class = %s, ClassLoader* = %p and library name %s.", class_name.c_str(), getCurrentlyActiveClassLoader(), getCurrentlyLoadingLibraryName().c_str());
 
   if(getCurrentlyActiveClassLoader() == NULL)
   {
-    logDebug("class_loader.class_loader_private: ALERT!!! A library containing plugins has been opened through a means other than through the class_loader or pluginlib package. This can happen if you build plugin libraries that contain more than just plugins (i.e. normal code your app links against). This inherently will trigger a dlopen() prior to main() and cause problems as class_loader is not aware of plugin factories that autoregister under the hood. The class_loader package can compensate, but you may run into namespace collision problems (e.g. if you have the same plugin class in two different libraries and you load them both at the same time). The biggest problem is that library can now no longer be safely unloaded as the ClassLoader does not know when non-plugin code is still in use. In fact, no ClassLoader instance in your application will be unable to unload any library once a non-pure one has been opened. Please refactor your code to isolate plugins into their own libraries.");
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: ALERT!!! A library containing plugins has been opened through a means other than through the class_loader or pluginlib package. This can happen if you build plugin libraries that contain more than just plugins (i.e. normal code your app links against). This inherently will trigger a dlopen() prior to main() and cause problems as class_loader is not aware of plugin factories that autoregister under the hood. The class_loader package can compensate, but you may run into namespace collision problems (e.g. if you have the same plugin class in two different libraries and you load them both at the same time). The biggest problem is that library can now no longer be safely unloaded as the ClassLoader does not know when non-plugin code is still in use. In fact, no ClassLoader instance in your application will be unable to unload any library once a non-pure one has been opened. Please refactor your code to isolate plugins into their own libraries.");
     hasANonPurePluginLibraryBeenOpened(true);    
   }
 
@@ -177,11 +177,11 @@ void registerPlugin(const std::string& class_name, const std::string& base_class
   getPluginBaseToFactoryMapMapMutex().lock();
   FactoryMap& factoryMap = getFactoryMapForBaseClass<Base>();
   if(factoryMap.find(class_name) != factoryMap.end())
-    logWarn("class_loader.class_loader_private: SEVERE WARNING!!! A namespace collision has occured with plugin factory for class %s. New factory will OVERWRITE existing one. This situation occurs when libraries containing plugins are directly linked against an executable (the one running right now generating this message). Please separate plugins out into their own library or just don't link against the library and use either class_loader::ClassLoader/MultiLibraryClassLoader to open.", class_name.c_str());
+    CONSOLE_BRIDGE_logWarn("class_loader.class_loader_private: SEVERE WARNING!!! A namespace collision has occured with plugin factory for class %s. New factory will OVERWRITE existing one. This situation occurs when libraries containing plugins are directly linked against an executable (the one running right now generating this message). Please separate plugins out into their own library or just don't link against the library and use either class_loader::ClassLoader/MultiLibraryClassLoader to open.", class_name.c_str());
   factoryMap[class_name] = new_factory;
   getPluginBaseToFactoryMapMapMutex().unlock();
 
-  logDebug("class_loader.class_loader_private: Registration of %s complete (Metaobject Address = %p)", class_name.c_str(), new_factory);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Registration of %s complete (Metaobject Address = %p)", class_name.c_str(), new_factory);
 }
 
 /**
@@ -201,7 +201,7 @@ Base* createInstance(const std::string& derived_class_name, ClassLoader* loader)
     factory = dynamic_cast<class_loader_private::AbstractMetaObject<Base>*>(factoryMap[derived_class_name]);
   else
   {
-    logError("class_loader.class_loader_private: No metaobject exists for class type %s.", derived_class_name.c_str());
+    CONSOLE_BRIDGE_logError("class_loader.class_loader_private: No metaobject exists for class type %s.", derived_class_name.c_str());
   }
   getPluginBaseToFactoryMapMapMutex().unlock();
 
@@ -213,7 +213,7 @@ Base* createInstance(const std::string& derived_class_name, ClassLoader* loader)
   {
     if(factory && factory->isOwnedBy(NULL))
     {
-      logDebug("class_loader.class_loader_private: ALERT!!! A metaobject (i.e. factory) exists for desired class, but has no owner. This implies that the library containing the class was dlopen()ed by means other than through the class_loader interface. This can happen if you build plugin libraries that contain more than just plugins (i.e. normal code your app links against) -- that intrinsically will trigger a dlopen() prior to main(). You should isolate your plugins into their own library, otherwise it will not be possible to shutdown the library!");
+      CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: ALERT!!! A metaobject (i.e. factory) exists for desired class, but has no owner. This implies that the library containing the class was dlopen()ed by means other than through the class_loader interface. This can happen if you build plugin libraries that contain more than just plugins (i.e. normal code your app links against) -- that intrinsically will trigger a dlopen() prior to main(). You should isolate your plugins into their own library, otherwise it will not be possible to shutdown the library!");
 
       obj = factory->create();
     }
@@ -221,7 +221,7 @@ Base* createInstance(const std::string& derived_class_name, ClassLoader* loader)
       throw(class_loader::CreateClassException("Could not create instance of type " + derived_class_name));
   }
 
-  logDebug("class_loader.class_loader_private: Created instance of type %s and object pointer = %p", (typeid(obj).name()), obj);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Created instance of type %s and object pointer = %p", (typeid(obj).name()), obj);
 
   return(obj);
 }

--- a/include/class_loader/class_loader_register_macro.h
+++ b/include/class_loader/class_loader_register_macro.h
@@ -33,6 +33,8 @@
 #include "class_loader_core.h"
 #include <console_bridge/console.h>
 
+#include "class_loader/console_bridge_compatibility.h"
+
 #define CLASS_LOADER_REGISTER_CLASS_INTERNAL_WITH_MESSAGE(Derived, Base, UniqueID, Message) \
 namespace \
 {\
@@ -43,7 +45,7 @@ namespace \
     ProxyExec##UniqueID() \
     { \
       if(std::string(Message)!="")\
-        logInform("%s", Message);\
+        CONSOLE_BRIDGE_logInform("%s", Message);\
       class_loader::class_loader_private::registerPlugin<_derived, _base>(#Derived, #Base); \
     }\
   };\

--- a/include/class_loader/console_bridge_compatibility.h
+++ b/include/class_loader/console_bridge_compatibility.h
@@ -1,0 +1,22 @@
+#ifndef CLASS_LOADER__CONSOLE_BRIDGE_COMPATIBILITY_H
+#define CLASS_LOADER__CONSOLE_BRIDGE_COMPATIBILITY_H
+
+#include <console_bridge/console.h>
+
+#ifndef CONSOLE_BRIDGE_logError
+#define CONSOLE_BRIDGE_logError logError
+#endif
+
+#ifndef CONSOLE_BRIDGE_logWarn
+#define CONSOLE_BRIDGE_logWarn logWarn
+#endif
+
+#ifndef CONSOLE_BRIDGE_logDebug
+#define CONSOLE_BRIDGE_logDebug logDebug
+#endif
+
+#ifndef CONSOLE_BRIDGE_logInform
+#define CONSOLE_BRIDGE_logInform logInform
+#endif
+
+#endif  // CLASS_LOADER__CONSOLE_BRIDGE_COMPATIBILITY_H

--- a/include/class_loader/meta_object.h
+++ b/include/class_loader/meta_object.h
@@ -36,6 +36,8 @@
 #include <vector>
 #include <typeinfo>
 
+#include "class_loader/console_bridge_compatibility.h"
+
 namespace class_loader
 {
 

--- a/include/class_loader/meta_object.h
+++ b/include/class_loader/meta_object.h
@@ -65,7 +65,7 @@ class AbstractMetaObjectBase
      * TEMPLATE SUBCLASSES, OTHERWISE THEY WILL PULL IN A REDUNDANT METAOBJECT
      * DESTRUCTOR OUTSIDE OF libclass_loader WITHIN THE PLUGIN LIBRARY! T
      */
-    ~AbstractMetaObjectBase();
+    virtual ~AbstractMetaObjectBase();
 
     /**
      * @brief Gets the literal name of the class.

--- a/include/class_loader/multi_library_class_loader.h
+++ b/include/class_loader/multi_library_class_loader.h
@@ -68,7 +68,7 @@ class MultiLibraryClassLoader
     template <class Base>
     boost::shared_ptr<Base> createInstance(const std::string& class_name)
     {
-      logDebug("class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.", class_name.c_str());
+      CONSOLE_BRIDGE_logDebug("class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.", class_name.c_str());
       ClassLoader* loader = getClassLoaderForClass<Base>(class_name);
       if (loader == NULL)
         throw class_loader::CreateClassException("MultiLibraryClassLoader: Could not create object of class type " + class_name + " as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");
@@ -103,7 +103,7 @@ class MultiLibraryClassLoader
     template <class Base>
     ClassLoader::UniquePtr<Base> createUniqueInstance(const std::string& class_name)
     {
-      logDebug("class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.", class_name.c_str());
+      CONSOLE_BRIDGE_logDebug("class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.", class_name.c_str());
       ClassLoader* loader = getClassLoaderForClass<Base>(class_name);
       if (loader == nullptr)
         throw class_loader::CreateClassException("MultiLibraryClassLoader: Could not create object of class type " + class_name + " as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");

--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -50,14 +50,14 @@ library_path_(library_path),
 load_ref_count_(0),
 plugin_ref_count_(0)
 {
-  logDebug("class_loader.ClassLoader: Constructing new ClassLoader (%p) bound to library %s.", this, library_path.c_str());
+  CONSOLE_BRIDGE_logDebug("class_loader.ClassLoader: Constructing new ClassLoader (%p) bound to library %s.", this, library_path.c_str());
   if(!isOnDemandLoadUnloadEnabled())
     loadLibrary();
 }
 
 ClassLoader::~ClassLoader()
 {
-  logDebug("class_loader.ClassLoader: Destroying class loader, unloading associated library...\n");
+  CONSOLE_BRIDGE_logDebug("class_loader.ClassLoader: Destroying class loader, unloading associated library...\n");
   unloadLibrary(); //TODO: while(unloadLibrary() > 0){} ??
 }
 
@@ -91,7 +91,7 @@ int ClassLoader::unloadLibraryInternal(bool lock_plugin_ref_count)
     plugin_ref_lock = boost::recursive_mutex::scoped_lock(plugin_ref_count_mutex_);
 
   if(plugin_ref_count_ > 0)
-    logWarn("class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.");
+    CONSOLE_BRIDGE_logWarn("class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.");
   else
   {
     load_ref_count_ = load_ref_count_ - 1;

--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -220,7 +220,7 @@ MetaObjectVector allMetaObjectsForLibraryOwnedBy(const std::string& library_path
 void insertMetaObjectIntoGraveyard(AbstractMetaObjectBase* meta_obj)
 /*****************************************************************************/
 {
-  logDebug("class_loader.class_loader_private: Inserting MetaObject (class = %s, base_class = %s, ptr = %p) into graveyard", meta_obj->className().c_str(), meta_obj->baseClassName().c_str(), meta_obj);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Inserting MetaObject (class = %s, base_class = %s, ptr = %p) into graveyard", meta_obj->className().c_str(), meta_obj->baseClassName().c_str(), meta_obj);
   getMetaObjectGraveyard().push_back(meta_obj);
 }
 
@@ -262,7 +262,7 @@ void destroyMetaObjectsForLibrary(const std::string& library_path, const ClassLo
 {
   boost::recursive_mutex::scoped_lock lock(getPluginBaseToFactoryMapMapMutex());
 
-  logDebug("class_loader.class_loader_private: Removing MetaObjects associated with library %s and class loader %p from global plugin-to-factorymap map.\n", library_path.c_str(), loader);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Removing MetaObjects associated with library %s and class loader %p from global plugin-to-factorymap map.\n", library_path.c_str(), loader);
 
   //We have to walk through all FactoryMaps to be sure
   BaseToFactoryMapMap& factory_map_map = getGlobalPluginBaseToFactoryMapMap();
@@ -270,7 +270,7 @@ void destroyMetaObjectsForLibrary(const std::string& library_path, const ClassLo
   for(itr = factory_map_map.begin(); itr != factory_map_map.end(); itr++)
     destroyMetaObjectsForLibrary(library_path, itr->second, loader);
 
-  logDebug("class_loader.class_loader_private: Metaobjects removed.");
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Metaobjects removed.");
 }
 
 bool areThereAnyExistingMetaObjectsForLibrary(const std::string& library_path)
@@ -351,7 +351,7 @@ void addClassLoaderOwnerForAllExistingMetaObjectsForLibrary(const std::string& l
   for(unsigned int c = 0; c < all_meta_objs.size(); c++)
   {
     AbstractMetaObjectBase* meta_obj = all_meta_objs.at(c);
-    logDebug("class_loader.class_loader_private: Tagging existing MetaObject %p (base = %s, derived = %s) with class loader %p (library path = %s).", meta_obj, meta_obj->baseClassName().c_str(), meta_obj->className().c_str(), loader, loader ? loader->getLibraryPath().c_str() : "NULL");
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Tagging existing MetaObject %p (base = %s, derived = %s) with class loader %p (library path = %s).", meta_obj, meta_obj->baseClassName().c_str(), meta_obj->className().c_str(), loader, loader ? loader->getLibraryPath().c_str() : "NULL");
     all_meta_objs.at(c)->addOwningClassLoader(loader);
   }
 }
@@ -367,7 +367,7 @@ void revivePreviouslyCreateMetaobjectsFromGraveyard(const std::string& library_p
     AbstractMetaObjectBase* obj = *itr;
     if(obj->getAssociatedLibraryPath() == library_path)
     {
-      logDebug("class_loader.class_loader_private: Resurrected factory metaobject from graveyard, class = %s, base_class = %s ptr = %p...bound to ClassLoader %p (library path = %s)", obj->className().c_str(), obj->baseClassName().c_str(), obj, loader, loader ? loader->getLibraryPath().c_str() : "NULL");
+      CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Resurrected factory metaobject from graveyard, class = %s, base_class = %s ptr = %p...bound to ClassLoader %p (library path = %s)", obj->className().c_str(), obj->baseClassName().c_str(), obj, loader, loader ? loader->getLibraryPath().c_str() : "NULL");
 
       obj->addOwningClassLoader(loader);
       assert(obj->typeidBaseClassName() != "UNSET");
@@ -391,18 +391,18 @@ void purgeGraveyardOfMetaobjects(const std::string& library_path, ClassLoader* l
     AbstractMetaObjectBase* obj = *itr;
     if(obj->getAssociatedLibraryPath() == library_path)
     {
-      logDebug("class_loader.class_loader_private: Purging factory metaobject from graveyard, class = %s, base_class = %s ptr = %p...bound to ClassLoader %p (library path = %s)", obj->className().c_str(), obj->baseClassName().c_str(), obj, loader, loader ? loader->getLibraryPath().c_str() : "NULL");      
+      CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Purging factory metaobject from graveyard, class = %s, base_class = %s ptr = %p...bound to ClassLoader %p (library path = %s)", obj->className().c_str(), obj->baseClassName().c_str(), obj, loader, loader ? loader->getLibraryPath().c_str() : "NULL");      
 
       bool is_address_in_graveyard_same_as_global_factory_map = std::find(all_meta_objs.begin(), all_meta_objs.end(), *itr) != all_meta_objs.end();
       itr = graveyard.erase(itr);
       if(delete_objs)
       {
         if(is_address_in_graveyard_same_as_global_factory_map)
-          logDebug("class_loader.class_loader_private: Newly created metaobject factory in global factory map map has same address as one in graveyard -- metaobject has been purged from graveyard but not deleted.");
+          CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Newly created metaobject factory in global factory map map has same address as one in graveyard -- metaobject has been purged from graveyard but not deleted.");
         else
         {
           assert(hasANonPurePluginLibraryBeenOpened() == false);
-          logDebug("class_loader.class_loader_private: Also destroying metaobject %p (class = %s, base_class = %s, library_path = %s) in addition to purging it from graveyard.", obj, obj->className().c_str(), obj->baseClassName().c_str(), obj->getAssociatedLibraryPath().c_str());
+          CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Also destroying metaobject %p (class = %s, base_class = %s, library_path = %s) in addition to purging it from graveyard.", obj, obj->className().c_str(), obj->baseClassName().c_str(), obj->getAssociatedLibraryPath().c_str());
           delete(obj); //Note: This is the only place where metaobjects can be destroyed
         }
       }
@@ -416,14 +416,14 @@ void loadLibrary(const std::string& library_path, ClassLoader* loader)
 /*****************************************************************************/
 {
   static boost::recursive_mutex loader_mutex;
-  logDebug("class_loader.class_loader_private: Attempting to load library %s on behalf of ClassLoader handle %p...\n", library_path.c_str(), loader);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Attempting to load library %s on behalf of ClassLoader handle %p...\n", library_path.c_str(), loader);
   boost::recursive_mutex::scoped_lock loader_lock(loader_mutex);
 
   //If it's already open, just update existing metaobjects to have an additional owner.
   if(isLibraryLoadedByAnybody(library_path))
   {
     boost::recursive_mutex::scoped_lock lock(getPluginBaseToFactoryMapMapMutex());
-    logDebug("class_loader.class_loader_private: Library already in memory, but binding existing MetaObjects to loader if necesesary.\n");
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Library already in memory, but binding existing MetaObjects to loader if necesesary.\n");
     addClassLoaderOwnerForAllExistingMetaObjectsForLibrary(library_path, loader);
     return;
   }
@@ -462,19 +462,19 @@ void loadLibrary(const std::string& library_path, ClassLoader* loader)
   }
 
   assert(library_handle != NULL);
-  logDebug("class_loader.class_loader_private: Successfully loaded library %s into memory (Poco::SharedLibrary handle = %p).", library_path.c_str(), library_handle);
+  CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Successfully loaded library %s into memory (Poco::SharedLibrary handle = %p).", library_path.c_str(), library_handle);
 
   //Graveyard scenario
   unsigned int num_lib_objs = allMetaObjectsForLibrary(library_path).size();
   if(num_lib_objs == 0)
   {
-    logDebug("class_loader.class_loader_private: Though the library %s was just loaded, it seems no factory metaobjects were registered. Checking factory graveyard for previously loaded metaobjects...", library_path.c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Though the library %s was just loaded, it seems no factory metaobjects were registered. Checking factory graveyard for previously loaded metaobjects...", library_path.c_str());
     revivePreviouslyCreateMetaobjectsFromGraveyard(library_path, loader);
     purgeGraveyardOfMetaobjects(library_path, loader, false); //Note: The 'false' indicates we don't want to invoke delete on the metaobject
   }
   else
   {
-    logDebug("class_loader.class_loader_private: Library %s generated new factory metaobjects on load. Destroying graveyarded objects from previous loads...", library_path.c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Library %s generated new factory metaobjects on load. Destroying graveyarded objects from previous loads...", library_path.c_str());
     purgeGraveyardOfMetaobjects(library_path, loader, true);
   }
 
@@ -489,11 +489,11 @@ void unloadLibrary(const std::string& library_path, ClassLoader* loader)
 { 
   if(hasANonPurePluginLibraryBeenOpened())
   {
-    logDebug("class_loader.class_loader_private: Cannot unload %s or ANY other library as a non-pure plugin library was opened. As class_loader has no idea which libraries class factories were exported from, it can safely close any library without potentially unlinking symbols that are still actively being used. You must refactor your plugin libraries to be made exclusively of plugins in order for this error to stop happening.", library_path.c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Cannot unload %s or ANY other library as a non-pure plugin library was opened. As class_loader has no idea which libraries class factories were exported from, it can safely close any library without potentially unlinking symbols that are still actively being used. You must refactor your plugin libraries to be made exclusively of plugins in order for this error to stop happening.", library_path.c_str());
   }
   else
   { 
-    logDebug("class_loader.class_loader_private: Unloading library %s on behalf of ClassLoader %p...", library_path.c_str(), loader);
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: Unloading library %s on behalf of ClassLoader %p...", library_path.c_str(), loader);
     boost::recursive_mutex::scoped_lock lock(getLoadedLibraryVectorMutex());
     LibraryVector& open_libraries =  getLoadedLibraryVector();
     LibraryVector::iterator itr = findLoadedLibrary(library_path);
@@ -508,14 +508,14 @@ void unloadLibrary(const std::string& library_path, ClassLoader* loader)
         //Remove from loaded library list as well if no more factories associated with said library
         if(!areThereAnyExistingMetaObjectsForLibrary(library_path))
         {
-          logDebug("class_loader.class_loader_private: There are no more MetaObjects left for %s so unloading library and removing from loaded library vector.\n", library_path.c_str());
+          CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: There are no more MetaObjects left for %s so unloading library and removing from loaded library vector.\n", library_path.c_str());
           library->unload();          
           assert(library->isLoaded() == false);
           delete(library);
           itr = open_libraries.erase(itr);
         }
         else
-          logDebug("class_loader.class_loader_private: MetaObjects still remain in memory meaning other ClassLoaders are still using library, keeping library %s open.", library_path.c_str());
+          CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private: MetaObjects still remain in memory meaning other ClassLoaders are still using library, keeping library %s open.", library_path.c_str());
         return;
       }
       catch(const Poco::RuntimeException& e)

--- a/src/meta_object.cpp
+++ b/src/meta_object.cpp
@@ -42,13 +42,13 @@ class_name_(class_name),
 typeid_base_class_name_("UNSET")
 /*****************************************************************************/
 {
-    logDebug("class_loader.class_loader_private.AbstractMetaObjectBase: Creating MetaObject %p (base = %s, derived = %s, library path = %s)", this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private.AbstractMetaObjectBase: Creating MetaObject %p (base = %s, derived = %s, library path = %s)", this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
 }
 
 AbstractMetaObjectBase::~AbstractMetaObjectBase()
 /*****************************************************************************/
 {
-    logDebug("class_loader.class_loader_private.AbstractMetaObjectBase: Destroying MetaObject %p (base = %s, derived = %s, library path = %s)", this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
+    CONSOLE_BRIDGE_logDebug("class_loader.class_loader_private.AbstractMetaObjectBase: Destroying MetaObject %p (base = %s, derived = %s, library path = %s)", this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
 } 
 
 std::string AbstractMetaObjectBase::className() const


### PR DESCRIPTION
This is a follow up on #52 .
It fixes a potential memory leak and the build warnings
related to the non virtual destructor of AbstractMetaObjectBase.

