### PR TITLE
Fully resolved placeholder to avoid confusion

### DIFF
--- a/include/class_loader/class_loader.h
+++ b/include/class_loader/class_loader.h
@@ -126,9 +126,8 @@ public:
     std::lock_guard<std::recursive_mutex> lock(plugin_ref_count_mutex_);
     ++plugin_ref_count_;
 
-    using namespace std::placeholders;
     std::shared_ptr<Base> smart_obj(
-      obj, std::bind(&class_loader::ClassLoader::onPluginDeletion<Base>, this, _1));
+      obj, std::bind(&class_loader::ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1));
     return smart_obj;
   }
 


### PR DESCRIPTION
Updated the use of the _1 placeholder to use the fully resolved namespace to avoid confusing the compiler in the event that boost/function.hpp was included.

There are some headers that include boost function (e.g., OgreMeshManager.h) that cause a conflict when the placeholder is specified without its namespace. This keeps that from happening.