### PR TITLE
Ros2 reenable tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(WIN32)
   target_compile_definitions(${PROJECT_NAME} PRIVATE "CLASS_LOADER_BUILDING_DLL")
 endif()
 
-if(AMENT_ENABLE_TESTING)
+if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 

--- a/include/class_loader/class_loader.h
+++ b/include/class_loader/class_loader.h
@@ -75,13 +75,11 @@ std::string systemLibraryFormat(const std::string & library_name);
 class ClassLoader
 {
 public:
-#if __cplusplus >= 201103L
   template<typename Base>
   using DeleterType = std::function<void (Base *)>;
 
   template<typename Base>
   using UniquePtr = std::unique_ptr<Base, DeleterType<Base>>;
-#endif
 
   /**
    * @brief  Constructor for ClassLoader
@@ -125,7 +123,6 @@ public:
     );
   }
 
-#if __cplusplus >= 201103L
   /// Generates an instance of loadable classes (i.e. class_loader).
   /**
    * It is not necessary for the user to call loadLibrary() as it will be
@@ -148,7 +145,6 @@ public:
       std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)
     );
   }
-#endif
 
   /// Generates an instance of loadable classes (i.e. class_loader).
   /**

--- a/include/class_loader/multi_library_class_loader.h
+++ b/include/class_loader/multi_library_class_loader.h
@@ -106,7 +106,6 @@ public:
     return loader->createInstance<Base>(class_name);
   }
 
-#if __cplusplus >= 201103L
   /// Creates an instance of an object of given class name with ancestor class Base
   /**
    * This version does not look in a specific library for the factory, but rather the first open library that defines the classs
@@ -152,7 +151,6 @@ public:
     }
     return loader->createUniqueInstance<Base>(class_name);
   }
-#endif
 
   /**
    * @brief Creates an instance of an object of given class name with ancestor class Base

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,16 @@ target_include_directories(${PROJECT_NAME}_TestPlugins2
 target_link_libraries(${PROJECT_NAME}_TestPlugins2 ${PROJECT_NAME})
 class_loader_hide_library_symbols(${PROJECT_NAME}_TestPlugins2)
 
-ament_add_gtest(${PROJECT_NAME}_utest utest.cpp)
+if(WIN32)
+  set(append_library_dirs "$<TARGET_FILE_DIR:${PROJECT_NAME}>;$<TARGET_FILE_DIR:${PROJECT_NAME}_TestPlugins1>")
+else()
+  set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+
+ament_add_gtest(${PROJECT_NAME}_utest utest.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}"
+)
+
 if(TARGET ${PROJECT_NAME}_utest)
   target_include_directories(${PROJECT_NAME}_utest
     PUBLIC "../include" ${console_bridge_INCLUDE_DIRS} ${Poco_INCLUDE_DIRS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,11 +27,16 @@ ament_add_gtest(${PROJECT_NAME}_utest utest.cpp
 if(TARGET ${PROJECT_NAME}_utest)
   target_include_directories(${PROJECT_NAME}_utest
     PUBLIC "../include" ${console_bridge_INCLUDE_DIRS} ${Poco_INCLUDE_DIRS})
-  target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME} ${Poco_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_utest
+    ${PROJECT_NAME}
+    ${Poco_LIBRARIES}
+  )
   if(NOT WIN32)
     target_link_libraries(${PROJECT_NAME}_utest pthread)
   endif()
-  add_dependencies(${PROJECT_NAME}_utest ${PROJECT_NAME}_TestPlugins1 ${PROJECT_NAME}_TestPlugins2)
+  add_dependencies(${PROJECT_NAME}_utest
+    ${PROJECT_NAME}_TestPlugins1
+    ${PROJECT_NAME}_TestPlugins2)
 endif()
 
 ament_add_gtest(${PROJECT_NAME}_unique_ptr_test unique_ptr_test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,25 +25,22 @@ if(TARGET ${PROJECT_NAME}_utest)
   add_dependencies(${PROJECT_NAME}_utest ${PROJECT_NAME}_TestPlugins1 ${PROJECT_NAME}_TestPlugins2)
 endif()
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
-  catkin_add_gtest(${PROJECT_NAME}_unique_ptr_test unique_ptr_test.cpp)
-  if(TARGET ${PROJECT_NAME}_unique_ptr_test)
-    target_link_libraries(${PROJECT_NAME}_unique_ptr_test
-      ${Boost_LIBRARIES}
-      ${class_loader_LIBRARIES}
-    )
-    set_target_properties(${PROJECT_NAME}_unique_ptr_test
-      PROPERTIES
-        COMPILE_FLAGS -std=c++11
-        LINK_FLAGS -std=c++11
-    )
-    add_dependencies(${PROJECT_NAME}_unique_ptr_test
-      ${PROJECT_NAME}_TestPlugins1
-      ${PROJECT_NAME}_TestPlugins2
-    )
+ament_add_gtest(${PROJECT_NAME}_unique_ptr_test unique_ptr_test.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}"
+)
+if(TARGET ${PROJECT_NAME}_unique_ptr_test)
+  target_include_directories(${PROJECT_NAME}_unique_ptr_test
+	  PUBLIC "../include" ${Poco_INCLUDE_DIRS})
+  target_link_libraries(${PROJECT_NAME}_unique_ptr_test
+    ${PROJECT_NAME}
+    ${Poco_LIBRARIES}
+  )
+  if(NOT WIN32)
+    target_link_libraries(${PROJECT_NAME}_unique_ptr_test pthread)
   endif()
+  add_dependencies(${PROJECT_NAME}_unique_ptr_test
+    ${PROJECT_NAME}_TestPlugins1
+    ${PROJECT_NAME}_TestPlugins2)
 endif()
 
 add_subdirectory(fviz_case_study)

--- a/test/fviz_case_study/CMakeLists.txt
+++ b/test/fviz_case_study/CMakeLists.txt
@@ -20,7 +20,15 @@ target_link_libraries(${PROJECT_NAME}_Test_FvizDefaultPlugin
   ${PROJECT_NAME} ${PROJECT_NAME}_Test_Fviz)
 class_loader_hide_library_symbols(${PROJECT_NAME}_Test_FvizDefaultPlugin)
 
-ament_add_gtest(${PROJECT_NAME}_fviz_test fviz_test.cpp)
+if(WIN32)
+  set(append_library_dirs "$<TARGET_FILE_DIR:${PROJECT_NAME}>;$<TARGET_FILE_DIR:${PROJECT_NAME}_TestPlugins1>")
+else()
+  set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+
+ament_add_gtest(${PROJECT_NAME}_fviz_test fviz_test.cpp
+ APPEND_LIBRARY_DIRS "${append_library_dirs}"
+)
 if(TARGET ${PROJECT_NAME}_fviz_test)
   target_include_directories(${PROJECT_NAME}_fviz_test
     PUBLIC "../include" ${console_bridge_INCLUDE_DIRS} ${Poco_INCLUDE_DIRS})

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -75,7 +75,7 @@ TEST(ClassLoaderUniquePtrTest, nonExistentPlugin)
 
     obj->saySomething();
   }
-  catch(const class_loader::CreateClassException& e)
+  catch(const class_loader::CreateClassException&)
   {
     SUCCEED();
     return;
@@ -126,7 +126,7 @@ TEST(ClassLoaderUniquePtrTest, threadSafety)
     ASSERT_FALSE(loader1.isLibraryLoaded());
 
   }
-  catch(const class_loader::ClassLoaderException& ex)
+  catch(const class_loader::ClassLoaderException&)
   {
     FAIL() << "Unexpected ClassLoaderException.";
   }
@@ -173,7 +173,7 @@ TEST(ClassLoaderUniquePtrTest, loadRefCountingLazy)
 
     return;
   }
-  catch(const class_loader::ClassLoaderException& e)
+  catch(const class_loader::ClassLoaderException&)
   {
     FAIL() << "Unexpected exception.\n";
   }

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -3,10 +3,13 @@
 #include <class_loader/multi_library_class_loader.h>
 
 #include <gtest/gtest.h>
-#include <boost/thread.hpp>
 
+#include <chrono>
 #include <functional>
 #include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
 
 const std::string LIBRARY_1 = "libclass_loader_TestPlugins1.so";
 const std::string LIBRARY_2 = "libclass_loader_TestPlugins2.so";
@@ -89,7 +92,7 @@ TEST(ClassLoaderUniquePtrTest, nonExistentPlugin)
 
 void wait(int seconds)
 {
-  boost::this_thread::sleep(boost::posix_time::seconds(seconds));
+  std::this_thread::sleep_for(std::chrono::seconds(seconds));
 }
 
 void run(ClassLoader* loader)
@@ -111,7 +114,7 @@ TEST(ClassLoaderUniquePtrTest, threadSafety)
   //or something if there's some implementation error.
   try
   {
-    std::vector<boost::thread> client_threads;
+    std::vector<std::thread> client_threads;
 
     for(unsigned int c = 0; c < 1000; c++)
       client_threads.emplace_back(std::bind(&run, &loader1));

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -11,8 +11,8 @@
 #include <thread>
 #include <vector>
 
-const std::string LIBRARY_1 = "libclass_loader_TestPlugins1.so";
-const std::string LIBRARY_2 = "libclass_loader_TestPlugins2.so";
+const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");
+const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");
 
 using class_loader::ClassLoader;
 

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -74,7 +74,7 @@ TEST(ClassLoaderTest, nonExistentPlugin)
     }
 
     obj->saySomething();
-  } catch (const class_loader::CreateClassException & e) {
+  } catch (const class_loader::CreateClassException &) {
     SUCCEED();
     return;
   } catch (...) {
@@ -88,7 +88,7 @@ TEST(ClassLoaderTest, nonExistentLibrary)
 {
   try {
     class_loader::ClassLoader loader1("libDoesNotExist.so", false);
-  } catch (const class_loader::LibraryLoadException & e) {
+  } catch (const class_loader::LibraryLoadException &) {
     SUCCEED();
     return;
   } catch (...) {
@@ -115,7 +115,7 @@ TEST(ClassLoaderTest, invalidBase)
     } else {
       FAIL() << "Class not available for correct base class.";
     }
-  } catch (const class_loader::LibraryLoadException & e) {
+  } catch (const class_loader::LibraryLoadException &) {
     FAIL() << "Unexpected exception";
   } catch (...) {
     FAIL() << "Unexpected and unknown exception caught.\n";
@@ -161,7 +161,7 @@ TEST(ClassLoaderTest, threadSafety)
     loader1.unloadLibrary();
     ASSERT_FALSE(loader1.isLibraryLoaded());
 
-  } catch (const class_loader::ClassLoaderException & ex) {
+  } catch (const class_loader::ClassLoaderException &) {
     FAIL() << "Unexpected ClassLoaderException.";
   } catch (...) {
     FAIL() << "Unknown exception.";
@@ -194,7 +194,7 @@ TEST(ClassLoaderTest, loadRefCountingNonLazy)
     ASSERT_TRUE(loader1.isLibraryLoaded());
 
     return;
-  } catch (const class_loader::ClassLoaderException & e) {
+  } catch (const class_loader::ClassLoaderException &) {
     FAIL() << "Unexpected exception.\n";
   } catch (...) {
     FAIL() << "Unknown exception caught.\n";
@@ -235,7 +235,7 @@ TEST(ClassLoaderTest, loadRefCountingLazy)
     ASSERT_TRUE(loader1.isLibraryLoaded());
 
     return;
-  } catch (const class_loader::ClassLoaderException & e) {
+  } catch (const class_loader::ClassLoaderException &) {
     FAIL() << "Unexpected exception.\n";
   } catch (...) {
     FAIL() << "Unknown exception caught.\n";


### PR DESCRIPTION
Opening for visibility.

Apparently class_loader tests have been disabled in ROS2 for a looong time (https://github.com/ament/ament_cmake/pull/68). This aims to reenable and fix them