### PR TITLE
[ros2] library suffix hack

### DIFF
--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -56,12 +56,17 @@ std::string systemLibraryPrefix()
 
 std::string systemLibrarySuffix()
 {
-#if !defined(WIN32)
-  return Poco::SharedLibrary::suffix();
-#else
-  // Return just .dll , as Poco::SharedLibrary::suffix() will return d.dll in debug mode.
-  // This isn't common for our usecase (instead debug libraries are placed in a `Debug` folder).
+// Poco should be compiled with `#define POCO_NO_SHARED_LIBRARY_DEBUG_SUFFIX`
+// to automatically remove the trailing `d` from the shared library suffix
+//   return Poco::SharedLibrary::suffix();
+#ifdef __linux__
+  return ".so";
+#elif __APPLE__
+  return ".dylib";
+#elif _WIN32
   return ".dll";
+#else
+  return Poco::SharedLibrary::suffix();
 #endif
 }
 


### PR DESCRIPTION
workaround for https://github.com/ros/class_loader/issues/31

See https://github.com/ros/class_loader/issues/31 for original issue description and a potential real fix description.
This is needed for https://github.com/ros/class_loader/pull/59 tests to pass in Debug mode 