### PR TITLE
Use std::string::empty instead comparing with an empty string

### DIFF
--- a/include/class_loader/class_loader_register_macro.h
+++ b/include/class_loader/class_loader_register_macro.h
@@ -46,7 +46,7 @@
     typedef  Base _base; \
     ProxyExec ## UniqueID() \
     { \
-      if (std::string(Message) != "") { \
+      if (not std::string(Message).empty()) { \
         CONSOLE_BRIDGE_logInform("%s", Message);} \
       class_loader::class_loader_private::registerPlugin<_derived, _base>(#Derived, #Base); \
     } \

--- a/include/class_loader/class_loader_register_macro.h
+++ b/include/class_loader/class_loader_register_macro.h
@@ -46,7 +46,7 @@
     typedef  Base _base; \
     ProxyExec ## UniqueID() \
     { \
-      if (not std::string(Message).empty()) { \
+      if (!std::string(Message).empty()) { \
         CONSOLE_BRIDGE_logInform("%s", Message);} \
       class_loader::class_loader_private::registerPlugin<_derived, _base>(#Derived, #Base); \
     } \


### PR DESCRIPTION
Caught by clang-tidy.