### PR TITLE
Appveyor improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,9 @@ version: 1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true
-os: Visual Studio 2015
+os:
+  - Visual Studio 2015
+  - Visual Studio 2017
 init:
   - cmd: rd /s /q %CHOCOLATEYINSTALL%
   - ps: iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))


### PR DESCRIPTION
- test VS2017 (this is actually not enough we need to source the right VS tools, currently VS14.0 used in both cases)