### PR TITLE
add nolint for global std::string used for testing

### DIFF
--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -42,8 +42,8 @@
 
 #include "./base.h"
 
-const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");
-const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");
+const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");  // NOLINT
+const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");  // NOLINT
 
 using class_loader::ClassLoader;
 

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -41,8 +41,8 @@
 
 #include "./base.h"
 
-const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");
-const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");
+const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");  // NOLINT
+const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");  // NOLINT
 
 TEST(ClassLoaderTest, basicLoad) {
   try {


### PR DESCRIPTION
Otherwise cpplint is not happy `For a static/global string constant, use a C style string instead`