### PR TITLE
Provide stl api

### DIFF
--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -134,11 +134,7 @@ public:
   /**
    * @brief  Generates an instance of loadable classes (i.e. class_loader).
    *
-   * It is not necessary for the user to call loadLibrary() as it will be invoked automatically
-   * if the library is not yet loaded (which typically happens when in "On Demand Load/Unload" mode).
-   *
-   * @param  derived_class_name The name of the class we want to create (@see getAvailableClasses())
-   * @return A boost::shared_ptr<Base> to newly created plugin object
+   * Same as createSharedInstance() except it returns a boost::shared_ptr.
    */
   template<class Base>
   boost::shared_ptr<Base> createInstance(const std::string & derived_class_name)

--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -121,6 +121,23 @@ public:
    * if the library is not yet loaded (which typically happens when in "On Demand Load/Unload" mode).
    *
    * @param  derived_class_name The name of the class we want to create (@see getAvailableClasses())
+   * @return A std::shared_ptr<Base> to newly created plugin object
+   */
+  template<class Base>
+  std::shared_ptr<Base> createSharedInstance(const std::string & derived_class_name)
+  {
+    return std::shared_ptr<Base>(
+      createRawInstance<Base>(derived_class_name, true),
+      boost::bind(&ClassLoader::onPluginDeletion<Base>, this, _1));
+  }
+
+  /**
+   * @brief  Generates an instance of loadable classes (i.e. class_loader).
+   *
+   * It is not necessary for the user to call loadLibrary() as it will be invoked automatically
+   * if the library is not yet loaded (which typically happens when in "On Demand Load/Unload" mode).
+   *
+   * @param  derived_class_name The name of the class we want to create (@see getAvailableClasses())
    * @return A boost::shared_ptr<Base> to newly created plugin object
    */
   template<class Base>

--- a/include/class_loader/multi_library_class_loader.hpp
+++ b/include/class_loader/multi_library_class_loader.hpp
@@ -120,6 +120,54 @@ public:
    * This version does not look in a specific library for the factory, but rather the first open library that defines the classs
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
+   * @return A std::shared_ptr<Base> to newly created plugin
+   */
+  template<class Base>
+  std::shared_ptr<Base> createSharedInstance(const std::string & class_name)
+  {
+    CONSOLE_BRIDGE_logDebug(
+      "class_loader::MultiLibraryClassLoader: "
+      "Attempting to create instance of class type %s.",
+      class_name.c_str());
+    ClassLoader * loader = getClassLoaderForClass<Base>(class_name);
+    if (nullptr == loader) {
+      throw class_loader::CreateClassException(
+              "MultiLibraryClassLoader: Could not create object of class type " +
+              class_name +
+              " as no factory exists for it. Make sure that the library exists and "
+              "was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");
+    }
+
+    return loader->createSharedInstance<Base>(class_name);
+  }
+
+  /**
+   * @brief Creates an instance of an object of given class name with ancestor class Base
+   * This version takes a specific library to make explicit the factory being used
+   * @param Base - polymorphic type indicating base class
+   * @param class_name - the name of the concrete plugin class we want to instantiate
+   * @param library_path - the library from which we want to create the plugin
+   * @return A std::shared_ptr<Base> to newly created plugin
+   */
+  template<class Base>
+  std::shared_ptr<Base>
+  createSharedInstance(const std::string & class_name, const std::string & library_path)
+  {
+    ClassLoader * loader = getClassLoaderForLibrary(library_path);
+    if (nullptr == loader) {
+      throw class_loader::NoClassLoaderExistsException(
+              "Could not create instance as there is no ClassLoader in "
+              "MultiLibraryClassLoader bound to library " + library_path +
+              " Ensure you called MultiLibraryClassLoader::loadLibrary()");
+    }
+    return loader->createSharedInstance<Base>(class_name);
+  }
+
+  /**
+   * @brief Creates an instance of an object of given class name with ancestor class Base
+   * This version does not look in a specific library for the factory, but rather the first open library that defines the classs
+   * @param Base - polymorphic type indicating base class
+   * @param class_name - the name of the concrete plugin class we want to instantiate
    * @return A unique pointer to newly created plugin
    */
   template<class Base>

--- a/include/class_loader/multi_library_class_loader.hpp
+++ b/include/class_loader/multi_library_class_loader.hpp
@@ -72,54 +72,6 @@ public:
    * This version does not look in a specific library for the factory, but rather the first open library that defines the classs
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
-   * @return A boost::shared_ptr<Base> to newly created plugin
-   */
-  template<class Base>
-  boost::shared_ptr<Base> createInstance(const std::string & class_name)
-  {
-    CONSOLE_BRIDGE_logDebug(
-      "class_loader::MultiLibraryClassLoader: "
-      "Attempting to create instance of class type %s.",
-      class_name.c_str());
-    ClassLoader * loader = getClassLoaderForClass<Base>(class_name);
-    if (nullptr == loader) {
-      throw class_loader::CreateClassException(
-              "MultiLibraryClassLoader: Could not create object of class type " +
-              class_name +
-              " as no factory exists for it. Make sure that the library exists and "
-              "was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");
-    }
-
-    return loader->createInstance<Base>(class_name);
-  }
-
-  /**
-   * @brief Creates an instance of an object of given class name with ancestor class Base
-   * This version takes a specific library to make explicit the factory being used
-   * @param Base - polymorphic type indicating base class
-   * @param class_name - the name of the concrete plugin class we want to instantiate
-   * @param library_path - the library from which we want to create the plugin
-   * @return A boost::shared_ptr<Base> to newly created plugin
-   */
-  template<class Base>
-  boost::shared_ptr<Base>
-  createInstance(const std::string & class_name, const std::string & library_path)
-  {
-    ClassLoader * loader = getClassLoaderForLibrary(library_path);
-    if (nullptr == loader) {
-      throw class_loader::NoClassLoaderExistsException(
-              "Could not create instance as there is no ClassLoader in "
-              "MultiLibraryClassLoader bound to library " + library_path +
-              " Ensure you called MultiLibraryClassLoader::loadLibrary()");
-    }
-    return loader->createInstance<Base>(class_name);
-  }
-
-  /**
-   * @brief Creates an instance of an object of given class name with ancestor class Base
-   * This version does not look in a specific library for the factory, but rather the first open library that defines the classs
-   * @param Base - polymorphic type indicating base class
-   * @param class_name - the name of the concrete plugin class we want to instantiate
    * @return A std::shared_ptr<Base> to newly created plugin
    */
   template<class Base>
@@ -147,7 +99,7 @@ public:
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
    * @param library_path - the library from which we want to create the plugin
-   * @return A std::shared_ptr<Base> to newly created plugin
+   * @return A boost::shared_ptr<Base> to newly created plugin
    */
   template<class Base>
   std::shared_ptr<Base>
@@ -165,10 +117,48 @@ public:
 
   /**
    * @brief Creates an instance of an object of given class name with ancestor class Base
-   * This version does not look in a specific library for the factory, but rather the first open library that defines the classs
-   * @param Base - polymorphic type indicating base class
-   * @param class_name - the name of the concrete plugin class we want to instantiate
-   * @return A unique pointer to newly created plugin
+   * Same as createSharedInstance() except it returns a boost::shared_ptr.
+   */
+  template<class Base>
+  boost::shared_ptr<Base> createInstance(const std::string & class_name)
+  {
+    CONSOLE_BRIDGE_logDebug(
+      "class_loader::MultiLibraryClassLoader: "
+      "Attempting to create instance of class type %s.",
+      class_name.c_str());
+    ClassLoader * loader = getClassLoaderForClass<Base>(class_name);
+    if (nullptr == loader) {
+      throw class_loader::CreateClassException(
+              "MultiLibraryClassLoader: Could not create object of class type " +
+              class_name +
+              " as no factory exists for it. Make sure that the library exists and "
+              "was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");
+    }
+
+    return loader->createInstance<Base>(class_name);
+  }
+
+  /**
+   * @brief Creates an instance of an object of given class name with ancestor class Base
+   * Same as createSharedInstance() except it returns a boost::shared_ptr.
+   */
+  template<class Base>
+  boost::shared_ptr<Base>
+  createInstance(const std::string & class_name, const std::string & library_path)
+  {
+    ClassLoader * loader = getClassLoaderForLibrary(library_path);
+    if (nullptr == loader) {
+      throw class_loader::NoClassLoaderExistsException(
+              "Could not create instance as there is no ClassLoader in "
+              "MultiLibraryClassLoader bound to library " + library_path +
+              " Ensure you called MultiLibraryClassLoader::loadLibrary()");
+    }
+    return loader->createInstance<Base>(class_name);
+  }
+
+  /**
+   * @brief Creates an instance of an object of given class name with ancestor class Base
+   * Same as createSharedInstance() except it returns a std::unique_ptr.
    */
   template<class Base>
   ClassLoader::UniquePtr<Base> createUniqueInstance(const std::string & class_name)
@@ -189,11 +179,7 @@ public:
 
   /**
    * @brief Creates an instance of an object of given class name with ancestor class Base
-   * This version takes a specific library to make explicit the factory being used
-   * @param Base - polymorphic type indicating base class
-   * @param class_name - the name of the concrete plugin class we want to instantiate
-   * @param library_path - the library from which we want to create the plugin
-   * @return A unique pointer to newly created plugin
+   * Same as createSharedInstance() except it returns a std::unique_ptr.
    */
   template<class Base>
   ClassLoader::UniquePtr<Base>

--- a/include/class_loader/multi_library_class_loader.hpp
+++ b/include/class_loader/multi_library_class_loader.hpp
@@ -99,7 +99,7 @@ public:
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
    * @param library_path - the library from which we want to create the plugin
-   * @return A boost::shared_ptr<Base> to newly created plugin
+   * @return A std::shared_ptr<Base> to newly created plugin
    */
   template<class Base>
   std::shared_ptr<Base>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,12 @@ if(TARGET ${PROJECT_NAME}_utest)
   add_dependencies(${PROJECT_NAME}_utest ${PROJECT_NAME}_TestPlugins1 ${PROJECT_NAME}_TestPlugins2)
 endif()
 
+catkin_add_gtest(${PROJECT_NAME}_shared_ptr_test shared_ptr_test.cpp)
+if(TARGET ${PROJECT_NAME}_shared_ptr_test)
+  target_link_libraries(${PROJECT_NAME}_shared_ptr_test ${Boost_LIBRARIES} ${class_loader_LIBRARIES})
+  add_dependencies(${PROJECT_NAME}_shared_ptr_test ${PROJECT_NAME}_TestPlugins1 ${PROJECT_NAME}_TestPlugins2)
+endif()
+
 catkin_add_gtest(${PROJECT_NAME}_unique_ptr_test unique_ptr_test.cpp)
 if(TARGET ${PROJECT_NAME}_unique_ptr_test)
   target_link_libraries(${PROJECT_NAME}_unique_ptr_test ${Boost_LIBRARIES} ${class_loader_LIBRARIES})

--- a/test/shared_ptr_test.cpp
+++ b/test/shared_ptr_test.cpp
@@ -45,7 +45,7 @@
 const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");  // NOLINT
 const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");  // NOLINT
 
-TEST(ClassLoaderTest, basicLoad) {
+TEST(ClassLoaderSharedPtrTest, basicLoad) {
   try {
     class_loader::ClassLoader loader1(LIBRARY_1, false);
     loader1.createSharedInstance<Base>("Cat")->saySomething();  // See if lazy load works
@@ -56,7 +56,7 @@ TEST(ClassLoaderTest, basicLoad) {
   SUCCEED();
 }
 
-TEST(ClassLoaderTest, correctNonLazyLoadUnload) {
+TEST(ClassLoaderSharedPtrTest, correctNonLazyLoadUnload) {
   try {
     ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
     class_loader::ClassLoader loader1(LIBRARY_1, false);
@@ -73,7 +73,7 @@ TEST(ClassLoaderTest, correctNonLazyLoadUnload) {
   }
 }
 
-TEST(ClassLoaderTest, correctLazyLoadUnload) {
+TEST(ClassLoaderSharedPtrTest, correctLazyLoadUnload) {
   try {
     ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
     class_loader::ClassLoader loader1(LIBRARY_1, true);
@@ -96,7 +96,7 @@ TEST(ClassLoaderTest, correctLazyLoadUnload) {
   }
 }
 
-TEST(ClassLoaderTest, nonExistentPlugin) {
+TEST(ClassLoaderSharedPtrTest, nonExistentPlugin) {
   class_loader::ClassLoader loader1(LIBRARY_1, false);
 
   try {
@@ -116,7 +116,7 @@ TEST(ClassLoaderTest, nonExistentPlugin) {
   FAIL() << "Did not throw exception as expected.\n";
 }
 
-TEST(ClassLoaderTest, nonExistentLibrary) {
+TEST(ClassLoaderSharedPtrTest, nonExistentLibrary) {
   try {
     class_loader::ClassLoader loader1("libDoesNotExist.so", false);
   } catch (const class_loader::LibraryLoadException &) {
@@ -133,7 +133,7 @@ class InvalidBase
 {
 };
 
-TEST(ClassLoaderTest, invalidBase) {
+TEST(ClassLoaderSharedPtrTest, invalidBase) {
   try {
     class_loader::ClassLoader loader1(LIBRARY_1, false);
     if (loader1.isClassAvailable<InvalidBase>("Cat")) {
@@ -164,7 +164,7 @@ void run(class_loader::ClassLoader * loader)
   }
 }
 
-TEST(ClassLoaderTest, threadSafety) {
+TEST(ClassLoaderSharedPtrTest, threadSafety) {
   class_loader::ClassLoader loader1(LIBRARY_1);
   ASSERT_TRUE(loader1.isLibraryLoaded());
 
@@ -195,7 +195,7 @@ TEST(ClassLoaderTest, threadSafety) {
   }
 }
 
-TEST(ClassLoaderTest, loadRefCountingNonLazy) {
+TEST(ClassLoaderSharedPtrTest, loadRefCountingNonLazy) {
   try {
     class_loader::ClassLoader loader1(LIBRARY_1, false);
     ASSERT_TRUE(loader1.isLibraryLoaded());
@@ -229,7 +229,7 @@ TEST(ClassLoaderTest, loadRefCountingNonLazy) {
   FAIL() << "Did not throw exception as expected.\n";
 }
 
-TEST(ClassLoaderTest, loadRefCountingLazy) {
+TEST(ClassLoaderSharedPtrTest, loadRefCountingLazy) {
   try {
     class_loader::ClassLoader loader1(LIBRARY_1, true);
     ASSERT_FALSE(loader1.isLibraryLoaded());

--- a/test/shared_ptr_test.cpp
+++ b/test/shared_ptr_test.cpp
@@ -48,7 +48,7 @@ const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_Te
 TEST(ClassLoaderTest, basicLoad) {
   try {
     class_loader::ClassLoader loader1(LIBRARY_1, false);
-    loader1.createInstance<Base>("Cat")->saySomething();  // See if lazy load works
+    loader1.createSharedInstance<Base>("Cat")->saySomething();  // See if lazy load works
   } catch (class_loader::ClassLoaderException & e) {
     FAIL() << "ClassLoaderException: " << e.what() << "\n";
   }
@@ -58,12 +58,12 @@ TEST(ClassLoaderTest, basicLoad) {
 
 TEST(ClassLoaderTest, correctNonLazyLoadUnload) {
   try {
-    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
     class_loader::ClassLoader loader1(LIBRARY_1, false);
-    ASSERT_TRUE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_TRUE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
     ASSERT_TRUE(loader1.isLibraryLoaded());
     loader1.unloadLibrary();
-    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
     ASSERT_FALSE(loader1.isLibraryLoaded());
     return;
   } catch (class_loader::ClassLoaderException & e) {
@@ -75,19 +75,19 @@ TEST(ClassLoaderTest, correctNonLazyLoadUnload) {
 
 TEST(ClassLoaderTest, correctLazyLoadUnload) {
   try {
-    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
     class_loader::ClassLoader loader1(LIBRARY_1, true);
-    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
     ASSERT_FALSE(loader1.isLibraryLoaded());
 
     {
-      boost::shared_ptr<Base> obj = loader1.createInstance<Base>("Cat");
-      ASSERT_TRUE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+      std::shared_ptr<Base> obj = loader1.createSharedInstance<Base>("Cat");
+      ASSERT_TRUE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
       ASSERT_TRUE(loader1.isLibraryLoaded());
     }
 
     // The library will unload automatically when the only plugin object left is destroyed
-    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
     return;
   } catch (class_loader::ClassLoaderException & e) {
     FAIL() << "ClassLoaderException: " << e.what() << "\n";
@@ -100,7 +100,7 @@ TEST(ClassLoaderTest, nonExistentPlugin) {
   class_loader::ClassLoader loader1(LIBRARY_1, false);
 
   try {
-    boost::shared_ptr<Base> obj = loader1.createInstance<Base>("Bear");
+    std::shared_ptr<Base> obj = loader1.createSharedInstance<Base>("Bear");
     if (nullptr == obj) {
       FAIL() << "Null object being returned instead of exception thrown.";
     }
@@ -160,7 +160,7 @@ void run(class_loader::ClassLoader * loader)
 {
   std::vector<std::string> classes = loader->getAvailableClasses<Base>();
   for (auto & class_ : classes) {
-    loader->createInstance<Base>(class_)->saySomething();
+    loader->createSharedInstance<Base>(class_)->saySomething();
   }
 }
 
@@ -235,7 +235,7 @@ TEST(ClassLoaderTest, loadRefCountingLazy) {
     ASSERT_FALSE(loader1.isLibraryLoaded());
 
     {
-      boost::shared_ptr<Base> obj = loader1.createInstance<Base>("Dog");
+      std::shared_ptr<Base> obj = loader1.createSharedInstance<Base>("Dog");
       ASSERT_TRUE(loader1.isLibraryLoaded());
     }
 
@@ -276,9 +276,9 @@ void testMultiClassLoader(bool lazy)
     loader.loadLibrary(LIBRARY_1);
     loader.loadLibrary(LIBRARY_2);
     for (int i = 0; i < 2; ++i) {
-      loader.createInstance<Base>("Cat")->saySomething();
-      loader.createInstance<Base>("Dog")->saySomething();
-      loader.createInstance<Base>("Robot")->saySomething();
+      loader.createSharedInstance<Base>("Cat")->saySomething();
+      loader.createSharedInstance<Base>("Dog")->saySomething();
+      loader.createSharedInstance<Base>("Robot")->saySomething();
     }
   } catch (class_loader::ClassLoaderException & e) {
     FAIL() << "ClassLoaderException: " << e.what() << "\n";
@@ -298,15 +298,15 @@ TEST(MultiClassLoaderTest, nonLazyLoad) {
 }
 TEST(MultiClassLoaderTest, noWarningOnLazyLoad) {
   try {
-    boost::shared_ptr<Base> cat, dog, rob;
+    std::shared_ptr<Base> cat, dog, rob;
     {
       class_loader::MultiLibraryClassLoader loader(true);
       loader.loadLibrary(LIBRARY_1);
       loader.loadLibrary(LIBRARY_2);
 
-      cat = loader.createInstance<Base>("Cat");
-      dog = loader.createInstance<Base>("Dog");
-      rob = loader.createInstance<Base>("Robot");
+      cat = loader.createSharedInstance<Base>("Cat");
+      dog = loader.createSharedInstance<Base>("Dog");
+      rob = loader.createSharedInstance<Base>("Robot");
     }
     cat->saySomething();
     dog->saySomething();

--- a/test/shared_ptr_test.cpp
+++ b/test/shared_ptr_test.cpp
@@ -58,12 +58,12 @@ TEST(ClassLoaderSharedPtrTest, basicLoad) {
 
 TEST(ClassLoaderSharedPtrTest, correctNonLazyLoadUnload) {
   try {
-    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
     class_loader::ClassLoader loader1(LIBRARY_1, false);
-    ASSERT_TRUE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_TRUE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
     ASSERT_TRUE(loader1.isLibraryLoaded());
     loader1.unloadLibrary();
-    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
     ASSERT_FALSE(loader1.isLibraryLoaded());
     return;
   } catch (class_loader::ClassLoaderException & e) {
@@ -75,19 +75,19 @@ TEST(ClassLoaderSharedPtrTest, correctNonLazyLoadUnload) {
 
 TEST(ClassLoaderSharedPtrTest, correctLazyLoadUnload) {
   try {
-    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
     class_loader::ClassLoader loader1(LIBRARY_1, true);
-    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
     ASSERT_FALSE(loader1.isLibraryLoaded());
 
     {
       std::shared_ptr<Base> obj = loader1.createSharedInstance<Base>("Cat");
-      ASSERT_TRUE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
+      ASSERT_TRUE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
       ASSERT_TRUE(loader1.isLibraryLoaded());
     }
 
     // The library will unload automatically when the only plugin object left is destroyed
-    ASSERT_FALSE(class_loader::class_loader_private::isLibraryLoadedByAnybody(LIBRARY_1));
+    ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
     return;
   } catch (class_loader::ClassLoaderException & e) {
     FAIL() << "ClassLoaderException: " << e.what() << "\n";

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -32,12 +32,13 @@
 #include <class_loader/multi_library_class_loader.hpp>
 
 #include <gtest/gtest.h>
-#include <boost/thread.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <functional>
 #include <iostream>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "./base.hpp"
@@ -102,7 +103,7 @@ TEST(ClassLoaderUniquePtrTest, nonExistentPlugin) {
 
 void wait(int seconds)
 {
-  boost::this_thread::sleep(boost::posix_time::seconds(seconds));
+  std::this_thread::sleep_for(std::chrono::seconds(seconds));
 }
 
 void run(ClassLoader * loader)
@@ -121,7 +122,7 @@ TEST(ClassLoaderUniquePtrTest, threadSafety) {
   // The hope is this test is hard enough that once in a while it'll segfault
   // or something if there's some implementation error.
   try {
-    std::vector<boost::thread> client_threads;
+    std::vector<std::thread> client_threads;
 
     for (size_t c = 0; c < 1000; c++) {
       client_threads.emplace_back(std::bind(&run, &loader1));


### PR DESCRIPTION
Provides an std::shared_ptr interfaces to createInstance (named createSharedInstance) for class_loader and multi_library_class_loader.
It also removes the use of boost::thread and boost::posix_time in the tests in favor of std::thread and std::chrono.

The tests have been duplicated for now to cover the new API but should be refactored to avoid code duplication. Ticketed at https://github.com/ros/class_loader/issues/94

closes #92 