### PR TITLE
free impl_ in AbstractMetaObjectBase destructor

### DIFF
--- a/src/meta_object.cpp
+++ b/src/meta_object.cpp
@@ -71,6 +71,7 @@ AbstractMetaObjectBase::~AbstractMetaObjectBase()
     "class_loader.impl.AbstractMetaObjectBase: "
     "Destroying MetaObject %p (base = %s, derived = %s, library path = %s)",
     this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
+  delete impl_;
 }
 
 const std::string & AbstractMetaObjectBase::className() const


### PR DESCRIPTION
The constructor allocates field impl_ of class_loader::impl::AbstractMetaObjectBase but the destructor and whatever functions it calls do not free it.

Signed-off-by: Chris Ye <chris.ye@intel.com>