### PR TITLE
fix CI missing catkin_pkg and console_bridge_vendor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,7 @@ install:
   - set "PATH=%PATH%;C:\Python35"
   - python --version
   - python -m pip install -U setuptools pip
+  - python -m pip install catkin_pkg
   - python -m pip install EmPy
   - python -m pip install trollius
   - python -m pip install pyparsing

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,7 @@ install:
   - cd src
   - python -c "import shutil; shutil.copytree('../..', './class_loader', ignore=shutil.ignore_patterns('build'))"
   - git clone https://github.com/ros/console_bridge.git
+  - git clone https://github.com/ros2/console_bridge_vendor.git
   - git clone https://github.com/ros2/poco_vendor.git
   - mkdir ament
   - cd ament

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   - git clone https://github.com/ament/googletest
   - cd ..
   - git clone https://github.com/ros/console_bridge.git
+  - git clone https://github.com/ros2/console_bridge_vendor.git
   - git clone https://github.com/ros2/poco_vendor.git
   - cd ..
   # Link source into workspace's source space

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
     else
       if ! brew ls --version cmake &>/dev/null; then brew install cmake; fi
     fi
+  - pip install catkin_pkg
 script:
   - mkdir -p build/src/ament
   - cd build


### PR DESCRIPTION
As mentioned in https://github.com/ros/class_loader/pull/103#issuecomment-419299945