### PR TITLE
improve warning message

### DIFF
--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -114,12 +114,11 @@ int ClassLoader::unloadLibraryInternal(bool lock_plugin_ref_count)
   }
 
   if (plugin_ref_count_ > 0) {
-    CONSOLE_BRIDGE_logWarn("%s",
-      "class_loader.ClassLoader: "
-      "SEVERE WARNING!!! Attempting to unload library while objects created by this loader "
-      "exist in the heap! "
-      "You should delete your objects before attempting to unload the library or "
-      "destroying the ClassLoader. The library will NOT be unloaded.");
+    CONSOLE_BRIDGE_logWarn("class_loader.ClassLoader: SEVERE WARNING!!!\n"
+                           "Attempting to unload %s\n"
+                           "while objects created by this library still exist in the heap!\n"
+                           "You should delete your objects before destroying the ClassLoader. "
+                           "The library will NOT be unloaded.", library_path_.c_str());
   } else {
     load_ref_count_ = load_ref_count_ - 1;
     if (0 == load_ref_count_) {


### PR DESCRIPTION
We often see the SEVERE warning message in MoveIt. Let's have it nicely formatted though:
- show affected library name
- nicer formatting into several lines