### PR TITLE
use #pragma message() to print out warning in MSVC

### DIFF
--- a/include/class_loader/class_loader.h
+++ b/include/class_loader/class_loader.h
@@ -32,9 +32,14 @@
 #ifndef CLASS_LOADER__CLASS_LOADER_H_
 #define CLASS_LOADER__CLASS_LOADER_H_
 
+#ifndef _MSC_VER
 // *INDENT-OFF* (prevent uncrustify from adding indention below)
 #warning Including header <class_loader/class_loader.h> is deprecated, \
 include <class_loader/class_loader.hpp> instead.
+#else
+#pragma message("Including header <class_loader/class_loader.h> is deprecated,")
+#pragma message("include <class_loader/class_loader.hpp> instead.")
+#endif
 
 #include "./class_loader.hpp"
 

--- a/include/class_loader/class_loader.h
+++ b/include/class_loader/class_loader.h
@@ -32,13 +32,13 @@
 #ifndef CLASS_LOADER__CLASS_LOADER_H_
 #define CLASS_LOADER__CLASS_LOADER_H_
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+#pragma message("Including header <class_loader/class_loader.h> is deprecated,")
+#pragma message("include <class_loader/class_loader.hpp> instead.")
+#else
 // *INDENT-OFF* (prevent uncrustify from adding indention below)
 #warning Including header <class_loader/class_loader.h> is deprecated, \
 include <class_loader/class_loader.hpp> instead.
-#else
-#pragma message("Including header <class_loader/class_loader.h> is deprecated,")
-#pragma message("include <class_loader/class_loader.hpp> instead.")
 #endif
 
 #include "./class_loader.hpp"

--- a/include/class_loader/class_loader_core.h
+++ b/include/class_loader/class_loader_core.h
@@ -32,9 +32,14 @@
 #ifndef CLASS_LOADER__CLASS_LOADER_CORE_H_
 #define CLASS_LOADER__CLASS_LOADER_CORE_H_
 
+#ifdef _MSC_VER
+#pragma message("Including header <class_loader/class_loader_core.h> is deprecated,")
+#pragma message("include <class_loader/class_loader_core.h> instead.")
+#else
 // *INDENT-OFF* (prevent uncrustify from adding indention below)
 #warning Including header <class_loader/class_loader_core.h> is deprecated, \
 include <class_loader/class_loader_core.hpp> instead.
+#endif
 
 #include "./class_loader_core.hpp"
 

--- a/include/class_loader/class_loader_exceptions.h
+++ b/include/class_loader/class_loader_exceptions.h
@@ -32,9 +32,14 @@
 #ifndef CLASS_LOADER__CLASS_LOADER_EXCEPTIONS_H_
 #define CLASS_LOADER__CLASS_LOADER_EXCEPTIONS_H_
 
+#ifdef _MSC_VER
+#pragma message("Including header <class_loader/class_loader_exceptions.h> is deprecated,")
+#pragma message("include <class_loader/class_loader_exceptions.h> instead.")
+#else
 // *INDENT-OFF* (prevent uncrustify from adding indention below)
 #warning Including header <class_loader/class_loader_exceptions.h> is deprecated, \
 include <class_loader/exceptions.hpp> instead.
+#endif
 
 #include "./exceptions.hpp"
 

--- a/include/class_loader/class_loader_register_macro.h
+++ b/include/class_loader/class_loader_register_macro.h
@@ -32,9 +32,14 @@
 #ifndef CLASS_LOADER__CLASS_LOADER_REGISTER_MACRO_H_
 #define CLASS_LOADER__CLASS_LOADER_REGISTER_MACRO_H_
 
+#ifdef _MSC_VER
+#pragma message("Including header <class_loader/class_loader_register_macro.h> is deprecated,")
+#pragma message("include <class_loader/class_loader_register_macro.h> instead.")
+#else
 // *INDENT-OFF* (prevent uncrustify from adding indention below)
 #warning Including header <class_loader/class_loader_register_macro.h> is deprecated, \
 include <class_loader/register_macro.hpp> instead.
+#endif
 
 #include "./register_macro.hpp"
 

--- a/include/class_loader/meta_object.h
+++ b/include/class_loader/meta_object.h
@@ -32,9 +32,14 @@
 #ifndef CLASS_LOADER__META_OBJECT_H_
 #define CLASS_LOADER__META_OBJECT_H_
 
+#ifdef _MSC_VER
+#pragma message("Including header <class_loader/meta_object.h> is deprecated,")
+#pragma message("include <class_loader/meta_object.h> instead.")
+#else
 // *INDENT-OFF* (prevent uncrustify from adding indention below)
 #warning Including header <class_loader/meta_object.h> is deprecated, \
 include <class_loader/meta_object.hpp> instead.
+#endif
 
 #include "./meta_object.hpp"
 

--- a/include/class_loader/multi_library_class_loader.h
+++ b/include/class_loader/multi_library_class_loader.h
@@ -32,9 +32,14 @@
 #ifndef CLASS_LOADER__MULTI_LIBRARY_CLASS_LOADER_H_
 #define CLASS_LOADER__MULTI_LIBRARY_CLASS_LOADER_H_
 
+#ifdef _MSC_VER
+#pragma message("Including header <class_loader/multi_library_class_loader.h> is deprecated,")
+#pragma message("include <class_loader/multi_library_class_loader.h> instead.")
+#else
 // *INDENT-OFF* (prevent uncrustify from adding indention below)
 #warning Including header <class_loader/multi_library_class_loader.h> is deprecated, \
 include <class_loader/multi_library_class_loader.hpp> instead.
+#endif
 
 #include "./multi_library_class_loader.hpp"
 


### PR DESCRIPTION
`#warning` does not work on MSVC, add `#ifdef _MSC_VER` block to add MSVC equivalent:
```
#pragma message(<warning>)
```

this only adds special handling for MSVC scenario, does not change Linux logics