### PR TITLE
avoid including Poco headers globally

### DIFF
--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -41,11 +41,15 @@
 #include <utility>
 #include <vector>
 
-#include "Poco/SharedLibrary.h"
-
 #include "class_loader/exceptions.hpp"
 #include "class_loader/meta_object.hpp"
 #include "class_loader/visibility_control.hpp"
+
+// forward declaration
+namespace Poco
+{
+  class SharedLibrary;
+}
 
 /**
  * @note This header file is the internal implementation of the plugin system which is exposed via the ClassLoader class

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -49,7 +49,7 @@
 namespace Poco
 {
   class SharedLibrary;
-}
+}  // namespace Poco
 
 /**
  * @note This header file is the internal implementation of the plugin system which is exposed via the ClassLoader class

--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -29,6 +29,7 @@
 
 #include "class_loader/class_loader.hpp"
 
+#include "Poco/SharedLibrary.h"
 #include <string>
 
 namespace class_loader

--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -29,8 +29,9 @@
 
 #include "class_loader/class_loader.hpp"
 
-#include "Poco/SharedLibrary.h"
 #include <string>
+
+#include "Poco/SharedLibrary.h"
 
 namespace class_loader
 {


### PR DESCRIPTION
use forward declaration to avoid including Poco headers globally