### PR TITLE
ignore warnings about import/exports when deriving from std classes on MSVC

### DIFF
--- a/include/class_loader/visibility_control.hpp
+++ b/include/class_loader/visibility_control.hpp
@@ -61,4 +61,11 @@
   #define CLASS_LOADER_PUBLIC_TYPE
 #endif
 
+// based on wiki.ros.org: http://wiki.ros.org/win_ros/Contributing/Dll%20Exports
+// Ignore warnings about import/exports when deriving from std classes.
+#ifdef _MSC_VER
+  #pragma warning(disable: 4251)
+  #pragma warning(disable: 4275)
+#endif
+
 #endif  // CLASS_LOADER__VISIBILITY_CONTROL_HPP_

--- a/include/class_loader/visibility_control.hpp
+++ b/include/class_loader/visibility_control.hpp
@@ -63,6 +63,8 @@
 
 // based on wiki.ros.org: http://wiki.ros.org/win_ros/Contributing/Dll%20Exports
 // Ignore warnings about import/exports when deriving from std classes.
+// https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251
+// https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275
 #ifdef _MSC_VER
   // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=vs-2017
   #pragma warning(disable: 4251)

--- a/include/class_loader/visibility_control.hpp
+++ b/include/class_loader/visibility_control.hpp
@@ -66,9 +66,7 @@
 // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251
 // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275
 #ifdef _MSC_VER
-  // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=vs-2017
   #pragma warning(disable: 4251)
-  // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=vs-2017
   #pragma warning(disable: 4275)
 #endif
 

--- a/include/class_loader/visibility_control.hpp
+++ b/include/class_loader/visibility_control.hpp
@@ -64,7 +64,9 @@
 // based on wiki.ros.org: http://wiki.ros.org/win_ros/Contributing/Dll%20Exports
 // Ignore warnings about import/exports when deriving from std classes.
 #ifdef _MSC_VER
+  // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=vs-2017
   #pragma warning(disable: 4251)
+  // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=vs-2017
   #pragma warning(disable: 4275)
 #endif
 


### PR DESCRIPTION
based on [ros wiki](http://wiki.ros.org/win_ros/Contributing/Dll%20Exports), ignore warnings about import/exports when deriving from std classes.