### PR TITLE
[Windows] Add missing export declaration in class_loader.hpp

### DIFF
--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -330,6 +330,7 @@ private:
   boost::recursive_mutex load_ref_count_mutex_;
   int plugin_ref_count_;
   boost::recursive_mutex plugin_ref_count_mutex_;
+  CLASS_LOADER_PUBLIC
   static bool has_unmananged_instance_been_created_;
 };
 


### PR DESCRIPTION
This is a missing change for class_loader.hpp. This is found by running ROS on Windows build against the upstream repo.

```
2019-01-31T07:06:08.4494844Z [100%] Linking CXX shared library D:\a\1\a\_output\devel_isolated\rosbag_storage\bin\rosbag_storage.dll
2019-01-31T07:06:08.4512456Z 	C:\opt\rosdeps\x64\bin\cmake.exe -E __create_def CMakeFiles\rosbag_storage.dir\exports.def CMakeFiles\rosbag_storage.dir\exports.def.objs
2019-01-31T07:06:08.4829231Z 	C:\opt\rosdeps\x64\bin\cmake.exe -E vs_link_dll --intdir=CMakeFiles\rosbag_storage.dir --manifests  -- "C:\PROGRA~2\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64\link.exe"  @CMakeFiles\rosbag_storage.dir\objects1.rsp @C:\Users\VssAdministrator\AppData\Local\Temp\nm64C8.tmp
2019-01-31T07:06:09.0630892Z LINK Pass 1: command "C:\PROGRA~2\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64\link.exe @CMakeFiles\rosbag_storage.dir\objects1.rsp /out:D:\a\1\a\_output\devel_isolated\rosbag_storage\bin\rosbag_storage.dll /implib:D:\a\1\a\_output\devel_isolated\rosbag_storage\lib\rosbag_storage.lib /pdb:D:\a\1\a\_symbols\rosbag_storage.pdb /dll /version:0.0 /machine:x64 /debug /INCREMENTAL /DEF:CMakeFiles\rosbag_storage.dir\exports.def C:\opt\ros\melodic\x64\lib\class_loader.lib C:\opt\rosdeps\x64\lib\PocoFoundation.lib C:\opt\ros\melodic\x64\lib\rosconsole.lib C:\opt\ros\melodic\x64\lib\rosconsole_log4cxx.lib C:\opt\ros\melodic\x64\lib\rosconsole_backend_interface.lib C:\opt\rosdeps\x64\lib\log4cxx.lib C:\opt\rosdeps\x64\lib\boost_regex-vc141-mt-x64-1_66.lib C:\opt\ros\melodic\x64\lib\roslib.lib C:\opt\ros\melodic\x64\lib\rospack.lib C:\opt\python27amd64\libs\python27.lib C:\opt\rosdeps\x64\lib\boost_filesystem-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_program_options-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\tinyxml2.lib C:\opt\ros\melodic\x64\lib\roslz4.lib C:\opt\rosdeps\x64\lib\lz4.lib C:\opt\ros\melodic\x64\lib\roscpp_serialization.lib C:\opt\ros\melodic\x64\lib\rostime.lib C:\opt\ros\melodic\x64\lib\cpp_common.lib C:\opt\rosdeps\x64\lib\boost_system-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_thread-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_chrono-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_date_time-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_atomic-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\console_bridge.lib C:\opt\rosdeps\x64\lib\boost_date_time-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_filesystem-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_program_options-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_regex-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_system-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\bz2.lib C:\opt\rosdeps\x64\lib\console_bridge.lib C:\opt\ros\melodic\x64\lib\roslib.lib C:\opt\ros\melodic\x64\lib\rospack.lib C:\opt\python27amd64\libs\python27.lib C:\opt\rosdeps\x64\lib\tinyxml2.lib C:\opt\ros\melodic\x64\lib\roslz4.lib C:\opt\rosdeps\x64\lib\lz4.lib C:\opt\ros\melodic\x64\lib\roscpp_serialization.lib C:\opt\ros\melodic\x64\lib\rostime.lib C:\opt\ros\melodic\x64\lib\cpp_common.lib C:\opt\rosdeps\x64\lib\boost_thread-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_chrono-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\boost_atomic-vc141-mt-x64-1_66.lib C:\opt\rosdeps\x64\lib\console_bridge.lib C:\opt\rosdeps\x64\lib\bz2.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:CMakeFiles\rosbag_storage.dir/intermediate.manifest CMakeFiles\rosbag_storage.dir/manifest.res" failed (exit code 1120) with the following output:
2019-01-31T07:06:09.0634028Z Microsoft (R) Incremental Linker Version 14.16.27026.1
2019-01-31T07:06:09.0634511Z Copyright (C) Microsoft Corporation.  All rights reserved.
2019-01-31T07:06:09.0634700Z 
2019-01-31T07:06:09.0634966Z CMakeFiles/rosbag_storage.dir/src/bag.cpp.obj CMakeFiles/rosbag_storage.dir/src/bag_player.cpp.obj CMakeFiles/rosbag_storage.dir/src/buffer.cpp.obj CMakeFiles/rosbag_storage.dir/src/bz2_stream.cpp.obj CMakeFiles/rosbag_storage.dir/src/lz4_stream.cpp.obj CMakeFiles/rosbag_storage.dir/src/chunked_file.cpp.obj CMakeFiles/rosbag_storage.dir/src/encryptor.cpp.obj CMakeFiles/rosbag_storage.dir/src/message_instance.cpp.obj CMakeFiles/rosbag_storage.dir/src/query.cpp.obj CMakeFiles/rosbag_storage.dir/src/stream.cpp.obj CMakeFiles/rosbag_storage.dir/src/view.cpp.obj CMakeFiles/rosbag_storage.dir/src/uncompressed_stream.cpp.obj 
2019-01-31T07:06:09.0641069Z NMAKE : fatal error U1077: 'C:\opt\rosdeps\x64\bin\cmake.exe' : return code '0xffffffff'
2019-01-31T07:06:09.0641222Z    Creating library D:\a\1\a\_output\devel_isolated\rosbag_storage\lib\rosbag_storage.lib and object D:\a\1\a\_output\devel_isolated\rosbag_storage\lib\rosbag_storage.exp
2019-01-31T07:06:09.0641348Z Stop.
2019-01-31T07:06:09.0646362Z bag.cpp.obj : error LNK2001: unresolved external symbol "private: static bool class_loader::ClassLoader::has_unmananged_instance_been_created_" (?has_unmananged_instance_been_created_@ClassLoader@class_loader@@0_NA)
2019-01-31T07:06:09.0647033Z D:\a\1\a\_output\devel_isolated\rosbag_storage\bin\rosbag_storage.dll : fatal error LNK1120: 1 unresolved externals
2019-01-31T07:06:09.0688318Z NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\nmake.exe"' : return code '0x2'
2019-01-31T07:06:09.0688439Z Stop.
2019-01-31T07:06:09.0701781Z NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\nmake.exe"' : return code '0x2'
2019-01-31T07:06:09.0701907Z Stop.
2019-01-31T07:06:09.0776809Z on "1.0.6") 
```