### PR TITLE
Find Poco library using upstream CMake configuration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 find_package(console_bridge REQUIRED)
 
 if(${catkin_FOUND})
-  find_package(catkin REQUIRED COMPONENTS cmake_modules)
   find_package(Poco REQUIRED COMPONENTS Foundation)
   catkin_package(
     INCLUDE_DIRS include

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,6 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend version_gte="0.3.3">cmake_modules</build_depend>
-
   <depend>boost</depend>
   <depend>libconsole-bridge-dev</depend>
   <depend>libpoco-dev</depend>


### PR DESCRIPTION
A bug in the FindPoco module from cmake_modules causes incorrect linking in Debug configurations.

I haven't decided if this is a straw man or not since I'm not sure what we gain or lose by not using the module from cmake_modules.

This is one possible way to resolve #117 but I'd like input from someone like @wjwwood before I decide whether this is a good idea or not.