### PR TITLE
Set AbstractMetaObjectBase base class typeid

### DIFF
--- a/include/class_loader/meta_object.hpp
+++ b/include/class_loader/meta_object.hpp
@@ -148,7 +148,7 @@ public:
    * @param name The literal name of the class.
    */
   AbstractMetaObject(const std::string & class_name, const std::string & base_class_name)
-  : AbstractMetaObjectBase(class_name, base_class_name)
+  : AbstractMetaObjectBase(class_name, base_class_name, typeid(B).name())
   {
   }
 


### PR DESCRIPTION
I've run into a bug when running in tests where the plugin class loader loads plugins, is destroyed, and upon re-loading plugins in the next test case it throws the following error:
```
1: [costmap_tests-3] footprint_tests_exec: /home/brian/ros2_ws/src/ros/class_loader/src/class_loader_core.cpp:369: void class_loader::impl::revivePreviouslyCreateMetaobjectsFromGraveyard(const string&, class_loader::ClassLoader*): Assertion `obj->typeidBaseClassName() != "UNSET"' failed.
```

Apparently, when attempting to revive the metaobjects it checks the assert, but after searching the code, it appears that the `typeid_base_class_name` in `AbstractMetaObjectBase` is default to "UNSET" and is never set anywhere. 

This PR sets that field when creating the `AbstractMetaObject` by setting the type id of the base class name, which seems to have been the intention. 