### PR TITLE
Reduce number of threads spun up on ARMHF platforms in stress test

### DIFF
--- a/test/base.hpp
+++ b/test/base.hpp
@@ -32,7 +32,7 @@
 
 // This was originally at 1000, but arm32 platforms we have tested on are not able to
 // successfully spin up 1000 threads in this test process. Using 500 as a reliably passing number.
-static constext size_t STRESS_TEST_NUM_THREADS = 500;
+static constexpr size_t STRESS_TEST_NUM_THREADS = 500;
 
 class Base
 {

--- a/test/base.hpp
+++ b/test/base.hpp
@@ -30,6 +30,12 @@
 #ifndef BASE_HPP_
 #define BASE_HPP_
 
+#if defined(__ARM_ARCH) && __ARM_ARCH <= 7
+static constexpr size_t STRESS_TEST_NUM_THREADS = 500;
+#else
+static constexpr size_t STRESS_TEST_NUM_THREADS = 1000;
+#endif
+
 class Base
 {
 public:

--- a/test/base.hpp
+++ b/test/base.hpp
@@ -30,11 +30,9 @@
 #ifndef BASE_HPP_
 #define BASE_HPP_
 
-#if defined(__ARM_ARCH) && __ARM_ARCH <= 7
-static constexpr size_t STRESS_TEST_NUM_THREADS = 500;
-#else
-static constexpr size_t STRESS_TEST_NUM_THREADS = 1000;
-#endif
+// This was originally at 1000, but arm32 platforms we have tested on are not able to
+// successfully spin up 1000 threads in this test process. Using 500 as a reliably passing number.
+static constext size_t STRESS_TEST_NUM_THREADS = 500;
 
 class Base
 {

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -124,7 +124,7 @@ TEST(ClassLoaderUniquePtrTest, threadSafety) {
   try {
     std::vector<std::thread> client_threads;
 
-    for (size_t c = 0; c < 1000; c++) {
+    for (size_t c = 0; c < STRESS_TEST_NUM_THREADS; c++) {
       client_threads.emplace_back(std::bind(&run, &loader1));
     }
 

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -45,12 +45,6 @@
 const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");  // NOLINT
 const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");  // NOLINT
 
-#if defined(__ARM_ARCH) && __ARM_ARCH <= 7
-static constexpr size_t STRESS_TEST_NUM_THREADS = 500;
-#else
-static constexpr size_t STRESS_TEST_NUM_THREADS = 1000;
-#endif
-
 TEST(ClassLoaderTest, basicLoad) {
   try {
     class_loader::ClassLoader loader1(LIBRARY_1, false);

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -45,6 +45,12 @@
 const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");  // NOLINT
 const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");  // NOLINT
 
+#if defined(__ARM_ARCH) && __ARM_ARCH <= 7
+static constexpr size_t STRESS_TEST_NUM_THREADS = 500;
+#else
+static constexpr size_t STRESS_TEST_NUM_THREADS = 1000;
+#endif
+
 TEST(ClassLoaderTest, basicLoad) {
   try {
     class_loader::ClassLoader loader1(LIBRARY_1, false);
@@ -174,7 +180,7 @@ TEST(ClassLoaderTest, threadSafety) {
   try {
     std::vector<std::thread *> client_threads;
 
-    for (size_t c = 0; c < 1000; ++c) {
+    for (size_t c = 0; c < STRESS_TEST_NUM_THREADS; ++c) {
       client_threads.push_back(new std::thread(std::bind(&run, &loader1)));
     }
 


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/721

In armhf platforms, the `std::thread` constructor starts to raise `Resource temporarily unavailable` at ~512 threads.

https://ci.ros2.org/job/ci_linux-armhf/lastCompletedBuild/testReport/(root)/class_loader/ - reproduces reliably on an AWS Graviton instance.

For these platforms, reduce the number of threads created to a level where (experimentally) it never fails.