### PR TITLE
[ROS 2] Correclty export class_loader library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ link_directories(${Poco_LIBRARY_DIR})
 if(ament_cmake_FOUND)
   ament_export_dependencies(console_bridge)
   ament_export_include_directories(include)
-  ament_export_libraries(${PROJECT_NAME})
 endif()
 
 set(${PROJECT_NAME}_SRCS
@@ -39,6 +38,7 @@ if(ament_cmake_FOUND)
   target_include_directories(${PROJECT_NAME}
     PUBLIC include)
   ament_target_dependencies(${PROJECT_NAME} "console_bridge" "Poco")
+  ament_export_libraries(${PROJECT_NAME})
 else()
   target_include_directories(${PROJECT_NAME}
     PUBLIC include ${console_bridge_INCLUDE_DIRS} ${Poco_INCLUDE_DIRS})


### PR DESCRIPTION
This fixes a bug that prevents building composable nodes using the ROS 2 dashing debian packages.

Before this PR `ament_export_libraries(class_loader)` is called before the library `class_loader` is created. This causes a [check in ament_export_libraries](https://github.com/ament/ament_cmake/blob/996fc382f77c77ed9315d29dfa6160a6d5db495d/ament_cmake_export_libraries/cmake/ament_export_libraries.cmake#L76) to determine that the name is not a target, and so it [calls `ament_export_library_names(class_loader)`](https://github.com/ament/ament_cmake/blob/996fc382f77c77ed9315d29dfa6160a6d5db495d/ament_cmake_export_libraries/cmake/ament_export_libraries.cmake#L123). That causes the name `class_loader` to be stored in [`_exported_library_names` instead of `_exported_libraries`](https://github.com/ament/ament_cmake/blob/996fc382f77c77ed9315d29dfa6160a6d5db495d/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in#L4). Plain library names are [searched using `find_library()` without any PATHS](https://github.com/ament/ament_cmake/blob/996fc382f77c77ed9315d29dfa6160a6d5db495d/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in#L110-L113). This fails.

Packages that `find_package(rclcpp_components)` emit a cmake warning like:

```
CMake Warning at /opt/ros/dashing/share/class_loader/cmake/ament_cmake_export_libraries-extras.cmake:117 (message):
  Package 'class_loader' exports library 'class_loader' which couldn't be
  found
Call Stack (most recent call first):
  /opt/ros/dashing/share/class_loader/cmake/class_loaderConfig.cmake:38 (include)
  /opt/ros/dashing/share/rclcpp_components/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package)
  /opt/ros/dashing/share/rclcpp_components/cmake/rclcpp_componentsConfig.cmake:38 (include)
  CMakeLists.txt:8 (find_package)
```

and fail to build composable nodes with linker errors

```
libsnap_nav.so: undefined reference to `class_loader::impl::getCurrentlyLoadingLibraryName[abi:cxx11]()'
libsnap_nav.so: undefined reference to `class_loader::impl::getPluginBaseToFactoryMapMapMutex()'
libsnap_nav.so: undefined reference to `class_loader::impl::hasANonPurePluginLibraryBeenOpened(bool)'
libsnap_nav.so: undefined reference to `class_loader::impl::getCurrentlyActiveClassLoader()'
libsnap_nav.so: undefined reference to `class_loader::impl::AbstractMetaObjectBase::setAssociatedLibraryPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
libsnap_nav.so: undefined reference to `class_loader::impl::getFactoryMapForBaseClass(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
libsnap_nav.so: undefined reference to `class_loader::impl::AbstractMetaObjectBase::AbstractMetaObjectBase(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
libsnap_nav.so: undefined reference to `class_loader::impl::AbstractMetaObjectBase::addOwningClassLoader(class_loader::ClassLoader*)'
collect2: error: ld returned 1 exit status
``` 

This PR fixes it by moving the call to `ament_export_libraries()` to after where the target is created. That changes the logic downstream packages use to `find_library(class_loader)` [to be one that specifies paths to `class_loader`'s lib directory](https://github.com/ament/ament_cmake/blob/996fc382f77c77ed9315d29dfa6160a6d5db495d/ament_cmake_export_libraries/cmake/ament_cmake_export_libraries-extras.cmake.in#L40-L44).

 I have no idea why the build farm didn't catch this. I think I would have expected [this job to be failing](http://build.ros2.org/job/Bbin_uB64__composition__ubuntu_bionic_amd64__binary/) but it's not. Something is causing `find_library(class_loader)` to succeed in the build farm, but not when I as a user do `find_package(rclcpp_components)`. The library path is `/opt/ros/dashing/lib/libclass_loader.so`, so maye a different package is adding `/opt/ros/dashing/lib` to `CMAKE_LIBRARY_PATH` in it's `<project>Config.cmake`?

Also, the logic in `ament_export_libraries()` should probably be moved to the package hook. I'll make a separate PR for that.

 I think it might also be the cause of https://answers.ros.org/question/327691/building-components-from-clion-doesnt-work/

