### PR TITLE
Use .empty() to check for an empty string.

### DIFF
--- a/include/class_loader/register_macro.hpp
+++ b/include/class_loader/register_macro.hpp
@@ -53,7 +53,7 @@
     typedef  Base _base; \
     ProxyExec ## UniqueID() \
     { \
-      if (std::string(Message) != "") { \
+      if (!std::string(Message).empty()) { \
         CONSOLE_BRIDGE_logInform("%s", Message); \
       } \
       class_loader::impl::registerPlugin<_derived, _base>(#Derived, #Base); \


### PR DESCRIPTION
This is essentially a port of PR #69 to ROS 2 so that clang-tidy
will stop complaining about it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>