### PR TITLE
[Dashing backport]: Use .empty() to check for an empty string. (#132)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
         brew update
         brew outdated cmake || brew upgrade cmake || brew install cmake
         brew install cppcheck console_bridge poco uncrustify
+        brew unlink python@2
         brew outdated python3 || brew upgrade python3 || brew install python3
     fi
   - python3 --version

--- a/include/class_loader/register_macro.hpp
+++ b/include/class_loader/register_macro.hpp
@@ -53,7 +53,7 @@
     typedef  Base _base; \
     ProxyExec ## UniqueID() \
     { \
-      if (std::string(Message) != "") { \
+      if (!std::string(Message).empty()) { \
         CONSOLE_BRIDGE_logInform("%s", Message); \
       } \
       class_loader::impl::registerPlugin<_derived, _base>(#Derived, #Base); \


### PR DESCRIPTION
This is essentially a port of PR #69 to ROS 2 so that clang-tidy
will stop complaining about it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is a backport of #132 to dashing.