### PR TITLE
Fix travis on macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
         brew update
         brew outdated cmake || brew upgrade cmake || brew install cmake
         brew install cppcheck console_bridge poco uncrustify
+        brew unlink python@2
         brew outdated python3 || brew upgrade python3 || brew install python3
     fi
   - python3 --version


### PR DESCRIPTION
When trying to install python3 from homebrew, travis was
complaining that it couldn't overwrite python2 symlinks
with python3 symlinks.  Follow the advice given by homebrew
and unlink python@2 before trying to install python3.  This
fixes travis on macOS for me.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>