### PR TITLE
[noetic][class_loader] declare specific boost dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,8 @@
 
   <build_depend version_gte="0.3.3">cmake_modules</build_depend>
 
-  <depend>boost</depend>
+  <depend>libboost-thread-dev</depend>
+  <depend>libboost-system-dev</depend>
   <depend>libconsole-bridge-dev</depend>
   <depend>libpoco-dev</depend>
 </package>


### PR DESCRIPTION
May be worth targeting to a noetic-devel to not impact released packages on other distributions

related to https://github.com/ros/ros_comm/pull/1871