### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -285,7 +285,8 @@ private:
       ClassLoader::hasUnmanagedInstanceBeenCreated() &&
       isOnDemandLoadUnloadEnabled())
     {
-      CONSOLE_BRIDGE_logInform("%s",
+      CONSOLE_BRIDGE_logInform(
+        "%s",
         "class_loader::ClassLoader: "
         "An attempt is being made to create a managed plugin instance (i.e. boost::shared_ptr), "
         "however an unmanaged instance was created within this process address space. "

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -197,7 +197,8 @@ void registerPlugin(const std::string & class_name, const std::string & base_cla
     getCurrentlyLoadingLibraryName().c_str());
 
   if (nullptr == getCurrentlyActiveClassLoader()) {
-    CONSOLE_BRIDGE_logDebug("%s",
+    CONSOLE_BRIDGE_logDebug(
+      "%s",
       "class_loader.impl: ALERT!!! "
       "A library containing plugins has been opened through a means other than through the "
       "class_loader or pluginlib package. "
@@ -274,7 +275,8 @@ Base * createInstance(const std::string & derived_class_name, ClassLoader * load
 
   if (nullptr == obj) {  // Was never created
     if (factory && factory->isOwnedBy(nullptr)) {
-      CONSOLE_BRIDGE_logDebug("%s",
+      CONSOLE_BRIDGE_logDebug(
+        "%s",
         "class_loader.impl: ALERT!!! "
         "A metaobject (i.e. factory) exists for desired class, but has no owner. "
         "This implies that the library containing the class was dlopen()ed by means other than "

--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -399,7 +399,8 @@ void purgeGraveyardOfMetaobjects(
       itr = graveyard.erase(itr);
       if (delete_objs) {
         if (is_address_in_graveyard_same_as_global_factory_map) {
-          CONSOLE_BRIDGE_logDebug("%s",
+          CONSOLE_BRIDGE_logDebug(
+            "%s",
             "class_loader.impl: "
             "Newly created metaobject factory in global factory map map has same address as "
             "one in graveyard -- metaobject has been purged from graveyard but not deleted.");
@@ -436,7 +437,8 @@ void loadLibrary(const std::string & library_path, ClassLoader * loader)
 
   // If it's already open, just update existing metaobjects to have an additional owner.
   if (isLibraryLoadedByAnybody(library_path)) {
-    CONSOLE_BRIDGE_logDebug("%s",
+    CONSOLE_BRIDGE_logDebug(
+      "%s",
       "class_loader.impl: "
       "Library already in memory, but binding existing MetaObjects to loader if necesesary.\n");
     addClassLoaderOwnerForAllExistingMetaObjectsForLibrary(library_path, loader);
@@ -587,7 +589,8 @@ void printDebugInfoToScreen()
   MetaObjectVector meta_objs = allMetaObjects();
   for (size_t c = 0; c < meta_objs.size(); c++) {
     AbstractMetaObjectBase * obj = meta_objs.at(c);
-    printf("Metaobject %zu (ptr = %p):\n TypeId = %s\n Associated Library = %s\n",
+    printf(
+      "Metaobject %zu (ptr = %p):\n TypeId = %s\n Associated Library = %s\n",
       c,
       reinterpret_cast<void *>(obj),
       (typeid(*obj).name()),
@@ -595,7 +598,8 @@ void printDebugInfoToScreen()
 
     size_t size = obj->getAssociatedClassLoadersCount();
     for (size_t i = 0; i < size; ++i) {
-      printf(" Associated Loader %zu = %p\n",
+      printf(
+        " Associated Loader %zu = %p\n",
         i, reinterpret_cast<void *>(obj->getAssociatedClassLoader(i)));
     }
     printf("--------------------------------------------------------------------------------\n");


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.