### PR TITLE
fix shebang line for python3

### DIFF
--- a/scripts/class_loader_headers_update.py
+++ b/scripts/class_loader_headers_update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2018, Open Source Robotics Foundation, Inc.


### PR DESCRIPTION
Currently in Noetic/Focal the script cannot be run with rosrun:
```
/usr/bin/env: ‘python’: No such file or directory
```