### PR TITLE
Update ROS 2 package maintainers.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,12 +6,14 @@
     The class_loader package is a ROS-independent package for loading plugins during runtime and the foundation of the higher level ROS "pluginlib" library.
     class_loader utilizes the host operating system's runtime loader to open runtime libraries (e.g. .so/.dll files), introspect the library for exported plugin classes, and allows users to instantiate objects of these exported classes without the explicit declaration (i.e. header file) for those classes.
   </description>
-  <maintainer email="stevenragnarok@osrfoundation.org">Steven! Ragnarök</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="michel@ekumenlabs.com">Michel Hidalgo</maintainer>
   <license>BSD</license>
 
   <url type="website">http://ros.org/wiki/class_loader</url>
   <author>Mirza Shah</author>
   <author>Dirk Thomas</author>
+  <author email="stevenragnarok@osrfoundation.org">Steven! Ragnarök</author>
 
   <build_depend>console_bridge_vendor</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>


### PR DESCRIPTION
Precisely what the title says, for `ros2` support.