### PR TITLE
Update ROS 1 package maintainers.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,8 @@
   <description>
     The class_loader package is a ROS-independent package for loading plugins during runtime and the foundation of the higher level ROS "pluginlib" library. class_loader utilizes the host operating system's runtime loader to open runtime libraries (e.g. .so/.dll files), introspect the library for exported plugin classes, and allows users to instantiate objects of said exported classes without the explicit declaration (i.e. header file) for those classes.
   </description>
-  <maintainer email="stevenragnarok@osrfoundation.org">Steven! Ragnarök</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="michel@ekumenlabs.com">Michel Hidalgo</maintainer>
   <license>BSD</license>
 
   <url type="website">http://ros.org/wiki/class_loader</url>
@@ -14,6 +15,7 @@
   <url type="repository">https://github.com/ros/class_loader</url>
 
   <author>Mirza Shah</author>
+  <author email="stevenragnarok@osrfoundation.org">Steven! Ragnarök</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 


### PR DESCRIPTION
Precisely what the title says, for `ros1` support.