### PR TITLE
Remove memory leaks

### DIFF
--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -135,10 +135,10 @@ public:
       static bool create_instance_message = false;
       if (!create_instance_message) {
         CONSOLE_BRIDGE_logWarn(
-          "To createUniqueInstance() with a class_loader::ClassLoader "
+          "To createInstance() with a class_loader::ClassLoader "
           "instance whose lifetime is not managed by an std::shared_ptr "
           "is deprecated.");
-          create_instance_message = true;
+        create_instance_message = true;
       }
       return std::shared_ptr<Base>(
         createRawInstance<Base>(derived_class_name, true),

--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -75,6 +75,8 @@ std::string systemLibraryFormat(const std::string & library_name);
  * @brief This class allows loading and unloading of dynamically linked libraries which contain class
  * definitions from which objects can be created/destroyed during runtime (i.e. class_loader).
  * Libraries loaded by a ClassLoader are only accessible within scope of that ClassLoader object.
+ * This class inherit from enable_shared_from_this which means we must used smart pointers,
+ * otherwise the code might work but it may run into a leak.
  */
 class ClassLoader : public std::enable_shared_from_this<ClassLoader>
 {
@@ -130,6 +132,8 @@ public:
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
     } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
+      CONSOLE_BRIDGE_logWarn("class_loader::ClassLoader::createUniqueInstance "
+        "This class must be used with smart pointer");
       return std::shared_ptr<Base>(
         createRawInstance<Base>(derived_class_name, true),
         std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)
@@ -160,6 +164,8 @@ public:
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
     } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
+      CONSOLE_BRIDGE_logWarn("class_loader::ClassLoader::createUniqueInstance "
+        "This class must be used with smart pointer");
       return std::unique_ptr<Base, DeleterType<Base>>(
         raw,
         std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)

--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -122,7 +122,8 @@ public:
    * @return A std::shared_ptr<Base> to newly created plugin object
    */
   template<class Base>
-  std::shared_ptr<Base> createInstance(const std::string & derived_class_name,
+  std::shared_ptr<Base> createInstance(
+    const std::string & derived_class_name,
     bool is_shared_ptr = false)
   {
     if (is_shared_ptr) {
@@ -152,19 +153,20 @@ public:
    * @return A std::unique_ptr<Base> to newly created plugin object.
    */
   template<class Base>
-  UniquePtr<Base> createUniqueInstance(const std::string & derived_class_name,
+  UniquePtr<Base> createUniqueInstance(
+    const std::string & derived_class_name,
     bool is_shared_ptr = false)
   {
     Base * raw = createRawInstance<Base>(derived_class_name, true);
     if (is_shared_ptr) {
       return std::unique_ptr<Base, DeleterType<Base>>(
         raw,
-        std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)
+        std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
     } else {
       return std::unique_ptr<Base, DeleterType<Base>>(
         raw,
-        std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
+        std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)
       );
     }
   }

--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -122,16 +122,14 @@ public:
    * @return A std::shared_ptr<Base> to newly created plugin object
    */
   template<class Base>
-  std::shared_ptr<Base> createInstance(
-    const std::string & derived_class_name,
-    bool is_shared_ptr = false)
+  std::shared_ptr<Base> createInstance(const std::string & derived_class_name)
   {
-    if (is_shared_ptr) {
+    try {
       return std::shared_ptr<Base>(
         createRawInstance<Base>(derived_class_name, true),
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
-    } else {
+    } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
       return std::shared_ptr<Base>(
         createRawInstance<Base>(derived_class_name, true),
         std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)
@@ -153,17 +151,15 @@ public:
    * @return A std::unique_ptr<Base> to newly created plugin object.
    */
   template<class Base>
-  UniquePtr<Base> createUniqueInstance(
-    const std::string & derived_class_name,
-    bool is_shared_ptr = false)
+  UniquePtr<Base> createUniqueInstance(const std::string & derived_class_name)
   {
     Base * raw = createRawInstance<Base>(derived_class_name, true);
-    if (is_shared_ptr) {
+    try {
       return std::unique_ptr<Base, DeleterType<Base>>(
         raw,
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
-    } else {
+    } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
       return std::unique_ptr<Base, DeleterType<Base>>(
         raw,
         std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)

--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -131,7 +131,7 @@ public:
         createRawInstance<Base>(derived_class_name, true),
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
-    } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
+    } catch (std::bad_weak_ptr &) {  // This is not a shared_ptr
       static bool create_instance_message = false;
       if (!create_instance_message) {
         CONSOLE_BRIDGE_logWarn(
@@ -169,7 +169,7 @@ public:
         raw,
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
-    } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
+    } catch (std::bad_weak_ptr &) {  // This is not a shared_ptr
       static bool create_unique_instance_message = false;
       if (!create_unique_instance_message) {
         CONSOLE_BRIDGE_logWarn(

--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -132,9 +132,14 @@ public:
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
     } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
-      CONSOLE_BRIDGE_logWarn(
-        "class_loader::ClassLoader::createUniqueInstance "
-        "This class must be used with smart pointer");
+      static bool create_instance_message = false;
+      if (!create_instance_message) {
+        CONSOLE_BRIDGE_logWarn(
+          "To createUniqueInstance() with a class_loader::ClassLoader "
+          "instance whose lifetime is not managed by an std::shared_ptr "
+          "is deprecated.");
+          create_instance_message = true;
+      }
       return std::shared_ptr<Base>(
         createRawInstance<Base>(derived_class_name, true),
         std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)
@@ -165,9 +170,14 @@ public:
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
     } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
-      CONSOLE_BRIDGE_logWarn(
-        "class_loader::ClassLoader::createUniqueInstance "
-        "This class must be used with smart pointer");
+      static bool create_unique_instance_message = false;
+      if (!create_unique_instance_message) {
+        CONSOLE_BRIDGE_logWarn(
+          "To createUniqueInstance() with a class_loader::ClassLoader "
+          "instance whose lifetime is not managed by an std::shared_ptr "
+          "is deprecated.");
+        create_unique_instance_message = true;
+      }
       return std::unique_ptr<Base, DeleterType<Base>>(
         raw,
         std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)

--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -132,7 +132,8 @@ public:
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
     } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
-      CONSOLE_BRIDGE_logWarn("class_loader::ClassLoader::createUniqueInstance "
+      CONSOLE_BRIDGE_logWarn(
+        "class_loader::ClassLoader::createUniqueInstance "
         "This class must be used with smart pointer");
       return std::shared_ptr<Base>(
         createRawInstance<Base>(derived_class_name, true),
@@ -164,7 +165,8 @@ public:
         std::bind(&ClassLoader::onPluginDeletion<Base>, shared_from_this(), std::placeholders::_1)
       );
     } catch (std::bad_weak_ptr & e) {  // This is not a shared_ptr
-      CONSOLE_BRIDGE_logWarn("class_loader::ClassLoader::createUniqueInstance "
+      CONSOLE_BRIDGE_logWarn(
+        "class_loader::ClassLoader::createUniqueInstance "
         "This class must be used with smart pointer");
       return std::unique_ptr<Base, DeleterType<Base>>(
         raw,

--- a/include/class_loader/multi_library_class_loader.hpp
+++ b/include/class_loader/multi_library_class_loader.hpp
@@ -154,7 +154,7 @@ public:
               "Make sure that the library exists and was explicitly loaded through "
               "MultiLibraryClassLoader::loadLibrary()");
     }
-    return loader->createUniqueInstance<Base>(class_name);
+    return loader->createUniqueInstance<Base>(class_name, true);
   }
 
   /// Creates an instance of an object of given class name with ancestor class Base
@@ -321,7 +321,8 @@ private:
    * @param library_path - the library from which we want to create the plugin
    * @return A pointer to the ClassLoader*, == nullptr if not found
    */
-  std::shared_ptr<class_loader::ClassLoader> getClassLoaderForLibrary(const std::string & library_path);
+  std::shared_ptr<class_loader::ClassLoader> getClassLoaderForLibrary(
+    const std::string & library_path);
 
   /// Gets a handle to the class loader corresponding to a specific class.
   /**

--- a/include/class_loader/multi_library_class_loader.hpp
+++ b/include/class_loader/multi_library_class_loader.hpp
@@ -105,7 +105,7 @@ public:
               "was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");
     }
 
-    return loader->createInstance<Base>(class_name, true);
+    return loader->createInstance<Base>(class_name);
   }
 
   /**
@@ -128,7 +128,7 @@ public:
               "MultiLibraryClassLoader bound to library " + library_path +
               " Ensure you called MultiLibraryClassLoader::loadLibrary()");
     }
-    return loader->createInstance<Base>(class_name, true);
+    return loader->createInstance<Base>(class_name);
   }
 
   /// Creates an instance of an object of given class name with ancestor class Base
@@ -154,7 +154,7 @@ public:
               "Make sure that the library exists and was explicitly loaded through "
               "MultiLibraryClassLoader::loadLibrary()");
     }
-    return loader->createUniqueInstance<Base>(class_name, true);
+    return loader->createUniqueInstance<Base>(class_name);
   }
 
   /// Creates an instance of an object of given class name with ancestor class Base
@@ -177,7 +177,7 @@ public:
               "MultiLibraryClassLoader bound to library " + library_path +
               " Ensure you called MultiLibraryClassLoader::loadLibrary()");
     }
-    return loader->createUniqueInstance<Base>(class_name, true);
+    return loader->createUniqueInstance<Base>(class_name);
   }
 
   /**

--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -545,6 +545,7 @@ void unloadLibrary(const std::string & library_path, ClassLoader * loader)
             ", keeping library %s open.",
             library_path.c_str());
         }
+        purgeGraveyardOfMetaobjects(library_path, loader, true);
         return;
       } catch (const std::runtime_error & e) {
         throw class_loader::LibraryUnloadException(

--- a/src/meta_object.cpp
+++ b/src/meta_object.cpp
@@ -71,6 +71,9 @@ AbstractMetaObjectBase::~AbstractMetaObjectBase()
     "class_loader.impl.AbstractMetaObjectBase: "
     "Destroying MetaObject %p (base = %s, derived = %s, library path = %s)",
     this, baseClassName().c_str(), className().c_str(), getAssociatedLibraryPath().c_str());
+  for (unsigned int i = 0; i < impl_->associated_class_loaders_.size(); i++) {
+    delete impl_->associated_class_loaders_[i];
+  }
   delete impl_;
 }
 

--- a/src/multi_library_class_loader.cpp
+++ b/src/multi_library_class_loader.cpp
@@ -68,7 +68,8 @@ std::vector<std::string> MultiLibraryClassLoader::getRegisteredLibraries() const
   return libraries;
 }
 
-ClassLoader * MultiLibraryClassLoader::getClassLoaderForLibrary(const std::string & library_path)
+std::shared_ptr<class_loader::ClassLoader> MultiLibraryClassLoader::getClassLoaderForLibrary(
+  const std::string & library_path)
 {
   return impl_->active_class_loaders_[library_path];
 }
@@ -93,7 +94,7 @@ void MultiLibraryClassLoader::loadLibrary(const std::string & library_path)
 {
   if (!isLibraryAvailable(library_path)) {
     impl_->active_class_loaders_[library_path] =
-      new class_loader::ClassLoader(library_path, isOnDemandLoadUnloadEnabled());
+      std::make_shared<class_loader::ClassLoader>(library_path, isOnDemandLoadUnloadEnabled());
   }
 }
 
@@ -108,11 +109,10 @@ int MultiLibraryClassLoader::unloadLibrary(const std::string & library_path)
 {
   int remaining_unloads = 0;
   if (isLibraryAvailable(library_path)) {
-    ClassLoader * loader = getClassLoaderForLibrary(library_path);
+    auto loader = getClassLoaderForLibrary(library_path);
     remaining_unloads = loader->unloadLibrary();
     if (remaining_unloads == 0) {
       impl_->active_class_loaders_[library_path] = nullptr;
-      delete (loader);
     }
   }
   return remaining_unloads;

--- a/src/multi_library_class_loader.cpp
+++ b/src/multi_library_class_loader.cpp
@@ -30,6 +30,7 @@
 #include "class_loader/multi_library_class_loader.hpp"
 
 #include <cstddef>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

I ran class_loader with asan and I found some memory leaks.

There is still one memory leak when we create unmanaged instance, the way to reproduce this leak is to run `basicLoadUnmanaged` and `noWarningOnLazyLoad` tests at the same time.

what is the right way to destroy this memory ?