### PR TITLE
Use boost library names instead of Boost_LIBRARIES var for .pc file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 if(NOT catkin_FOUND)
   set(TARGET_NAME ${PROJECT_NAME})
   set(PKGCONFIG_LIBS
-    ${Boost_LIBRARIES}
+    boost_thread boost_system
     ${console_bridge_LIBRARIES}
     ${Poco_LIBRARIES}
   )


### PR DESCRIPTION
This PR only affects the non-catkin case.

In recent versions of FindBoost.cmake (e.g. on Ubuntu 20.04),
Boost_LIBRARIES contains the cmake targets (Boost::thread,
Boost::system) instead of library names.

pkg-config --libs class_loader retruns
[...]-lclass_loader Boost::thread\;Boost::system\;[...]

Those cannot be linked downstream when cmake is not used or
find_package(Boost) is not executed again to actually find/define the
targets.