### PR TITLE
purge meta objects within the graveyard if the library is unassociated

### DIFF
--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -538,6 +538,7 @@ void unloadLibrary(const std::string & library_path, ClassLoader * loader)
 
           library->unload_library();
           itr = open_libraries.erase(itr);
+          purgeGraveyardOfMetaobjects(library_path, loader, true);
         } else {
           CONSOLE_BRIDGE_logDebug(
             "class_loader.impl: "


### PR DESCRIPTION
It seems that https://github.com/ros/class_loader/pull/196 is not updated as suggested by the maintainer for a few months. I would like to add @shshlei a `co-author` to create this PR to fix https://github.com/ros2/rcl/issues/1009.

**If this is not the correct way, please feel free to close it.**

Co-authored-by: shshlei <shshlei@hust.edu.cn>
Signed-off-by: Chen Lihui <lihui.chen@sony.com>