### PR TITLE
make the meta-object alive in the lifecycle of the registered plugin

### DIFF
--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -87,8 +87,10 @@ class MetaObjectGraveyardVector : public MetaObjectVector
 public:
   ~MetaObjectGraveyardVector()
   {
-    // make sure to destroy `meta_object` not to access the pointer value in the class loader plugin
-    // that could be unloaded before `g_register_plugin_ ## UniqueID` in some circumstances.
+    // Make sure not to access the pointer value in the static variable of `getMetaObjectGraveyard()
+    // when destroying `meta_object` in the unique_ptr deleter. Because the static variable in
+    // `getMetaObjectGraveyard()` could be finalized before the static variable
+    // `g_register_plugin_ ## UniqueID` in some circumstances.
     clear();
   }
 };

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -34,6 +34,7 @@
 
 #include <cstddef>
 #include <cstdio>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -81,6 +82,16 @@ typedef std::map<BaseClassName, FactoryMap> BaseToFactoryMapMap;
 typedef std::pair<LibraryPath, std::shared_ptr<rcpputils::SharedLibrary>> LibraryPair;
 typedef std::vector<LibraryPair> LibraryVector;
 typedef std::vector<AbstractMetaObjectBase *> MetaObjectVector;
+class MetaObjectGraveyardVector : public MetaObjectVector
+{
+public:
+  ~MetaObjectGraveyardVector()
+  {
+    // make sure to destroy `meta_object` not to access the pointer value in the class loader plugin
+    // that could be unloaded before `g_register_plugin_ ## UniqueID` in some circumstances.
+    clear();
+  }
+};
 
 CLASS_LOADER_PUBLIC
 void printDebugInfoToScreen();
@@ -165,6 +176,13 @@ FactoryMap & getFactoryMapForBaseClass()
 }
 
 /**
+ * @brief Gets a handle to a list of meta object of graveyard.
+ *
+ * @return A reference to the MetaObjectGraveyardVector contained within the meta object of graveyard.
+ */
+MetaObjectGraveyardVector & getMetaObjectGraveyard();
+
+/**
  * @brief To provide thread safety, all exposed plugin functions can only be run serially by multiple threads.
  *
  *  This is implemented by using critical sections enforced by a single mutex which is locked and
@@ -176,6 +194,8 @@ CLASS_LOADER_PUBLIC
 std::recursive_mutex & getLoadedLibraryVectorMutex();
 CLASS_LOADER_PUBLIC
 std::recursive_mutex & getPluginBaseToFactoryMapMapMutex();
+CLASS_LOADER_PUBLIC
+std::mutex & getMetaObjectGraveyardMutex();
 
 /**
  * @brief Indicates if a library containing more than just plugins has been opened by the running process
@@ -193,6 +213,12 @@ bool hasANonPurePluginLibraryBeenOpened();
 CLASS_LOADER_PUBLIC
 void hasANonPurePluginLibraryBeenOpened(bool hasIt);
 
+template<typename Base>
+using DeleterType = std::function<void (Base *)>;
+
+template<typename Base>
+using UniquePtr = std::unique_ptr<Base, DeleterType<Base>>;
+
 // Plugin Functions
 
 /**
@@ -207,7 +233,8 @@ void hasANonPurePluginLibraryBeenOpened(bool hasIt);
  * @param class_name - the literal name of the class being registered (NOT MANGLED)
  */
 template<typename Derived, typename Base>
-void registerPlugin(const std::string & class_name, const std::string & base_class_name)
+UniquePtr<AbstractMetaObjectBase>
+registerPlugin(const std::string & class_name, const std::string & base_class_name)
 {
   // Note: This function will be automatically invoked when a dlopen() call
   // opens a library. Normally it will happen within the scope of loadLibrary(),
@@ -240,8 +267,28 @@ void registerPlugin(const std::string & class_name, const std::string & base_cla
   }
 
   // Create factory
-  impl::AbstractMetaObject<Base> * new_factory =
-    new impl::MetaObject<Derived, Base>(class_name, base_class_name);
+  UniquePtr<AbstractMetaObjectBase> new_factory(
+    new impl::MetaObject<Derived, Base>(class_name, base_class_name),
+    [class_name](AbstractMetaObjectBase * p) {
+      getMetaObjectGraveyardMutex().lock();
+      MetaObjectGraveyardVector & graveyard = getMetaObjectGraveyard();
+      for (auto iter = graveyard.begin(); iter != graveyard.end(); ++iter) {
+        if (*iter == p) {
+          graveyard.erase(iter);
+          break;
+        }
+      }
+      getMetaObjectGraveyardMutex().unlock();
+
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
+#endif
+      delete (p);  // Note: This is the only place where metaobjects can be destroyed
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif
+    });
   new_factory->addOwningClassLoader(getCurrentlyActiveClassLoader());
   new_factory->setAssociatedLibraryPath(getCurrentlyLoadingLibraryName());
 
@@ -260,13 +307,14 @@ void registerPlugin(const std::string & class_name, const std::string & base_cla
       "and use either class_loader::ClassLoader/MultiLibraryClassLoader to open.",
       class_name.c_str());
   }
-  factoryMap[class_name] = new_factory;
+  factoryMap[class_name] = new_factory.get();
   getPluginBaseToFactoryMapMapMutex().unlock();
 
   CONSOLE_BRIDGE_logDebug(
     "class_loader.impl: "
     "Registration of %s complete (Metaobject Address = %p)",
-    class_name.c_str(), reinterpret_cast<void *>(new_factory));
+    class_name.c_str(), reinterpret_cast<void *>(new_factory.get()));
+  return new_factory;
 }
 
 /**

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -234,6 +234,7 @@ using UniquePtr = std::unique_ptr<Base, DeleterType<Base>>;
  * @param Derived - parameteric type indicating concrete type of plugin
  * @param Base - parameteric type indicating base type of plugin
  * @param class_name - the literal name of the class being registered (NOT MANGLED)
+ * @return A class_loader::impl::UniquePtr<AbstractMetaObjectBase> to newly created meta object.
  */
 template<typename Derived, typename Base>
 UniquePtr<AbstractMetaObjectBase>

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -89,8 +89,10 @@ public:
   {
     // Make sure not to access the pointer value in the static variable of `getMetaObjectGraveyard()
     // when destroying `meta_object` in the unique_ptr deleter. Because the static variable in
-    // `getMetaObjectGraveyard()` could be finalized before the static variable
+    // `getMetaObjectGraveyard()` can be destructed before the static variable
     // `g_register_plugin_ ## UniqueID` in some circumstances.
+    // NOTE of the vector dtor in the STL: if the elements themselves are pointers, the pointed-to
+    // memory is not touched in any way.  Managing the pointer is the user's responsibility.
     clear();
   }
 };

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -269,7 +269,7 @@ registerPlugin(const std::string & class_name, const std::string & base_class_na
   // Create factory
   UniquePtr<AbstractMetaObjectBase> new_factory(
     new impl::MetaObject<Derived, Base>(class_name, base_class_name),
-    [class_name](AbstractMetaObjectBase * p) {
+    [](AbstractMetaObjectBase * p) {
       getMetaObjectGraveyardMutex().lock();
       MetaObjectGraveyardVector & graveyard = getMetaObjectGraveyard();
       for (auto iter = graveyard.begin(); iter != graveyard.end(); ++iter) {

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -182,6 +182,7 @@ FactoryMap & getFactoryMapForBaseClass()
  *
  * @return A reference to the MetaObjectGraveyardVector contained within the meta object of graveyard.
  */
+CLASS_LOADER_PUBLIC
 MetaObjectGraveyardVector & getMetaObjectGraveyard();
 
 /**

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -194,8 +194,6 @@ CLASS_LOADER_PUBLIC
 std::recursive_mutex & getLoadedLibraryVectorMutex();
 CLASS_LOADER_PUBLIC
 std::recursive_mutex & getPluginBaseToFactoryMapMapMutex();
-CLASS_LOADER_PUBLIC
-std::mutex & getMetaObjectGraveyardMutex();
 
 /**
  * @brief Indicates if a library containing more than just plugins has been opened by the running process
@@ -270,7 +268,7 @@ registerPlugin(const std::string & class_name, const std::string & base_class_na
   UniquePtr<AbstractMetaObjectBase> new_factory(
     new impl::MetaObject<Derived, Base>(class_name, base_class_name),
     [](AbstractMetaObjectBase * p) {
-      getMetaObjectGraveyardMutex().lock();
+      getPluginBaseToFactoryMapMapMutex().lock();
       MetaObjectGraveyardVector & graveyard = getMetaObjectGraveyard();
       for (auto iter = graveyard.begin(); iter != graveyard.end(); ++iter) {
         if (*iter == p) {
@@ -278,7 +276,7 @@ registerPlugin(const std::string & class_name, const std::string & base_class_na
           break;
         }
       }
-      getMetaObjectGraveyardMutex().unlock();
+      getPluginBaseToFactoryMapMapMutex().unlock();
 
 #ifndef _WIN32
 #pragma GCC diagnostic push

--- a/include/class_loader/register_macro.hpp
+++ b/include/class_loader/register_macro.hpp
@@ -56,8 +56,10 @@
       if (!std::string(Message).empty()) { \
         CONSOLE_BRIDGE_logInform("%s", Message); \
       } \
-      class_loader::impl::registerPlugin<_derived, _base>(#Derived, #Base); \
+      holder = class_loader::impl::registerPlugin<_derived, _base>(#Derived, #Base); \
     } \
+private: \
+    class_loader::impl::UniquePtr<class_loader::impl::AbstractMetaObjectBase> holder; \
   }; \
   static ProxyExec ## UniqueID g_register_plugin_ ## UniqueID; \
   }  // namespace

--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -55,6 +55,12 @@ std::recursive_mutex & getPluginBaseToFactoryMapMapMutex()
   return m;
 }
 
+std::mutex & getMetaObjectGraveyardMutex()
+{
+  static std::mutex m;
+  return m;
+}
+
 BaseToFactoryMapMap & getGlobalPluginBaseToFactoryMapMap()
 {
   static BaseToFactoryMapMap instance;
@@ -72,9 +78,9 @@ FactoryMap & getFactoryMapForBaseClass(const std::string & typeid_base_class_nam
   return factoryMapMap[base_class_name];
 }
 
-MetaObjectVector & getMetaObjectGraveyard()
+MetaObjectGraveyardVector & getMetaObjectGraveyard()
 {
-  static MetaObjectVector instance;
+  static MetaObjectGraveyardVector instance;
   return instance;
 }
 
@@ -214,7 +220,9 @@ void insertMetaObjectIntoGraveyard(AbstractMetaObjectBase * meta_obj)
     "Inserting MetaObject (class = %s, base_class = %s, ptr = %p) into graveyard",
     meta_obj->className().c_str(), meta_obj->baseClassName().c_str(),
     reinterpret_cast<void *>(meta_obj));
+  getMetaObjectGraveyardMutex().lock();
   getMetaObjectGraveyard().push_back(meta_obj);
+  getMetaObjectGraveyardMutex().unlock();
 }
 
 void destroyMetaObjectsForLibrary(
@@ -352,7 +360,7 @@ void revivePreviouslyCreateMetaobjectsFromGraveyard(
   const std::string & library_path, ClassLoader * loader)
 {
   std::lock_guard<std::recursive_mutex> b2fmm_lock(getPluginBaseToFactoryMapMapMutex());
-  MetaObjectVector & graveyard = getMetaObjectGraveyard();
+  MetaObjectGraveyardVector & graveyard = getMetaObjectGraveyard();
 
   for (auto & obj : graveyard) {
     if (obj->getAssociatedLibraryPath() == library_path) {
@@ -373,14 +381,14 @@ void revivePreviouslyCreateMetaobjectsFromGraveyard(
 }
 
 void purgeGraveyardOfMetaobjects(
-  const std::string & library_path, ClassLoader * loader, bool delete_objs)
+  const std::string & library_path, ClassLoader * loader)
 {
   MetaObjectVector all_meta_objs = allMetaObjects();
   // Note: Lock must happen after call to allMetaObjects as that will lock
   std::lock_guard<std::recursive_mutex> b2fmm_lock(getPluginBaseToFactoryMapMapMutex());
 
-  MetaObjectVector & graveyard = getMetaObjectGraveyard();
-  MetaObjectVector::iterator itr = graveyard.begin();
+  MetaObjectGraveyardVector & graveyard = getMetaObjectGraveyard();
+  MetaObjectGraveyardVector::iterator itr = graveyard.begin();
 
   while (itr != graveyard.end()) {
     AbstractMetaObjectBase * obj = *itr;
@@ -393,34 +401,7 @@ void purgeGraveyardOfMetaobjects(
         reinterpret_cast<void *>(loader),
         nullptr == loader ? "NULL" : loader->getLibraryPath().c_str());
 
-      bool is_address_in_graveyard_same_as_global_factory_map =
-        std::find(all_meta_objs.begin(), all_meta_objs.end(), *itr) != all_meta_objs.end();
       itr = graveyard.erase(itr);
-      if (delete_objs) {
-        if (is_address_in_graveyard_same_as_global_factory_map) {
-          CONSOLE_BRIDGE_logDebug(
-            "%s",
-            "class_loader.impl: "
-            "Newly created metaobject factory in global factory map map has same address as "
-            "one in graveyard -- metaobject has been purged from graveyard but not deleted.");
-        } else {
-          assert(hasANonPurePluginLibraryBeenOpened() == false);
-          CONSOLE_BRIDGE_logDebug(
-            "class_loader.impl: "
-            "Also destroying metaobject %p (class = %s, base_class = %s, library_path = %s) "
-            "in addition to purging it from graveyard.",
-            reinterpret_cast<void *>(obj), obj->className().c_str(), obj->baseClassName().c_str(),
-            obj->getAssociatedLibraryPath().c_str());
-#ifndef _WIN32
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
-#endif
-          delete (obj);  // Note: This is the only place where metaobjects can be destroyed
-#ifndef _WIN32
-#pragma GCC diagnostic pop
-#endif
-        }
-      }
     } else {
       itr++;
     }
@@ -484,16 +465,14 @@ void loadLibrary(const std::string & library_path, ClassLoader * loader)
       "Checking factory graveyard for previously loaded metaobjects...",
       library_path.c_str());
     revivePreviouslyCreateMetaobjectsFromGraveyard(library_path, loader);
-    // Note: The 'false' indicates we don't want to invoke delete on the metaobject
-    purgeGraveyardOfMetaobjects(library_path, loader, false);
   } else {
     CONSOLE_BRIDGE_logDebug(
       "class_loader.impl: "
       "Library %s generated new factory metaobjects on load. "
       "Destroying graveyarded objects from previous loads...",
       library_path.c_str());
-    purgeGraveyardOfMetaobjects(library_path, loader, true);
   }
+  purgeGraveyardOfMetaobjects(library_path, loader);
 
   // Insert library into global loaded library vectory
   std::lock_guard<std::recursive_mutex> llv_lock(getLoadedLibraryVectorMutex());

--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -55,12 +55,6 @@ std::recursive_mutex & getPluginBaseToFactoryMapMapMutex()
   return m;
 }
 
-std::mutex & getMetaObjectGraveyardMutex()
-{
-  static std::mutex m;
-  return m;
-}
-
 BaseToFactoryMapMap & getGlobalPluginBaseToFactoryMapMap()
 {
   static BaseToFactoryMapMap instance;
@@ -220,9 +214,7 @@ void insertMetaObjectIntoGraveyard(AbstractMetaObjectBase * meta_obj)
     "Inserting MetaObject (class = %s, base_class = %s, ptr = %p) into graveyard",
     meta_obj->className().c_str(), meta_obj->baseClassName().c_str(),
     reinterpret_cast<void *>(meta_obj));
-  getMetaObjectGraveyardMutex().lock();
   getMetaObjectGraveyard().push_back(meta_obj);
-  getMetaObjectGraveyardMutex().unlock();
 }
 
 void destroyMetaObjectsForLibrary(

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -59,6 +59,34 @@ TEST(ClassLoaderUniquePtrTest, basicLoad) {
   }
 }
 
+TEST(ClassLoaderUniquePtrTest, basicLoadTwice) {
+  try {
+    {
+      ClassLoader loader1(LIBRARY_1, false);
+      loader1.createUniqueInstance<Base>("Cat")->saySomething();  // See if lazy load works
+    }
+    ClassLoader loader1(LIBRARY_1, false);
+    loader1.createUniqueInstance<Base>("Cat")->saySomething();  // See if lazy load works
+    ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
+    SUCCEED();
+  } catch (class_loader::ClassLoaderException & e) {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+}
+
+TEST(ClassLoaderUniquePtrTest, basicLoadTwiceSameTime) {
+  try {
+    ClassLoader loader1(LIBRARY_1, false);
+    loader1.createUniqueInstance<Base>("Cat")->saySomething();  // See if lazy load works
+    ClassLoader loader2(LIBRARY_1, false);
+    loader2.createUniqueInstance<Base>("Cat")->saySomething();  // See if lazy load works
+    ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
+    SUCCEED();
+  } catch (class_loader::ClassLoaderException & e) {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+}
+
 TEST(ClassLoaderUniquePtrTest, basicLoadFailures) {
   ClassLoader loader1(LIBRARY_1, false);
   ClassLoader loader2("", false);

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -67,6 +67,38 @@ TEST(ClassLoaderTest, basicLoad) {
   SUCCEED();
 }
 
+TEST(ClassLoaderTest, basicLoadTwice) {
+  try {
+    {
+      class_loader::ClassLoader loader1(LIBRARY_1, false);
+      ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
+      loader1.createInstance<Base>("Cat")->saySomething();  // See if lazy load works
+    }
+    class_loader::ClassLoader loader1(LIBRARY_1, false);
+    ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
+    loader1.createInstance<Base>("Cat")->saySomething();  // See if lazy load works
+  } catch (class_loader::ClassLoaderException & e) {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+
+  SUCCEED();
+}
+
+TEST(ClassLoaderTest, basicLoadTwiceSameTime) {
+  try {
+    class_loader::ClassLoader loader1(LIBRARY_1, false);
+    ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
+    loader1.createInstance<Base>("Cat")->saySomething();  // See if lazy load works
+    class_loader::ClassLoader loader2(LIBRARY_1, false);
+    ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
+    loader2.createInstance<Base>("Cat")->saySomething();  // See if lazy load works
+  } catch (class_loader::ClassLoaderException & e) {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+
+  SUCCEED();
+}
+
 // Requires separate namespace so static variables are isolated
 TEST(ClassLoaderUnmanagedTest, basicLoadUnmanaged) {
   try {


### PR DESCRIPTION
This PR is to address the memory leak about the meta-object is not destroyed during a process exit if using `ClassLoader`.

<details><summary> memory leak log </summary>
<p>

```shell
chenlh test $ valgrind --leak-check=full ./class_loader_unique_ptr_test --gtest_filter="*.basicLoad"
==63164== Memcheck, a memory error detector
==63164== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==63164== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==63164== Command: ./class_loader_unique_ptr_test --gtest_filter=*.basicLoad
==63164== 
Note: Google Test filter = *.basicLoad
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ClassLoaderUniquePtrTest
[ RUN      ] ClassLoaderUniquePtrTest.basicLoad
Meow
*******************************************************************************
*****                 class_loader impl DEBUG INFORMATION                 *****
*******************************************************************************
OPEN LIBRARIES IN MEMORY:
--------------------------------------------------------------------------------
Open library 0 = libclass_loader_TestPlugins1.so (handle = 0x4ede240)
METAOBJECTS (i.e. FACTORIES) IN MEMORY:
--------------------------------------------------------------------------------
Metaobject 0 (ptr = 0x4edf050):
 TypeId = N12class_loader4impl10MetaObjectI3Cat4BaseEE
 Associated Library = libclass_loader_TestPlugins1.so
 Associated Loader 0 = 0x1ffeff8000
--------------------------------------------------------------------------------
Metaobject 1 (ptr = 0x4edf6b0):
 TypeId = N12class_loader4impl10MetaObjectI3Cow4BaseEE
 Associated Library = libclass_loader_TestPlugins1.so
 Associated Loader 0 = 0x1ffeff8000
--------------------------------------------------------------------------------
Metaobject 2 (ptr = 0x4edec70):
 TypeId = N12class_loader4impl10MetaObjectI3Dog4BaseEE
 Associated Library = libclass_loader_TestPlugins1.so
 Associated Loader 0 = 0x1ffeff8000
--------------------------------------------------------------------------------
Metaobject 3 (ptr = 0x4edf380):
 TypeId = N12class_loader4impl10MetaObjectI4Duck4BaseEE
 Associated Library = libclass_loader_TestPlugins1.so
 Associated Loader 0 = 0x1ffeff8000
--------------------------------------------------------------------------------
Metaobject 4 (ptr = 0x4edf9e0):
 TypeId = N12class_loader4impl10MetaObjectI5Sheep4BaseEE
 Associated Library = libclass_loader_TestPlugins1.so
 Associated Loader 0 = 0x1ffeff8000
--------------------------------------------------------------------------------
********************************** END DEBUG **********************************
*******************************************************************************

[       OK ] ClassLoaderUniquePtrTest.basicLoad (161 ms)
[----------] 1 test from ClassLoaderUniquePtrTest (167 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (196 ms total)
[  PASSED  ] 1 test.
==63164== 
==63164== HEAP SUMMARY:
==63164==     in use at exit: 1,040 bytes in 20 blocks
==63164==   total heap usage: 502 allocs, 482 frees, 129,843 bytes allocated
==63164== 
==63164== 208 (16 direct, 192 indirect) bytes in 1 blocks are definitely lost in loss record 16 of 20
==63164==    at 0x483DE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==63164==    by 0x48A81A0: ???
==63164==    by 0x48A7667: ???
==63164==    by 0x48A7E35: ???
==63164==    by 0x48A7E7F: ???
==63164==    by 0x4011B99: call_init.part.0 (dl-init.c:72)
==63164==    by 0x4011CA0: call_init (dl-init.c:30)
==63164==    by 0x4011CA0: _dl_init (dl-init.c:119)
==63164==    by 0x4C8E984: _dl_catch_exception (dl-error-skeleton.c:182)
==63164==    by 0x40160CE: dl_open_worker (dl-open.c:758)
==63164==    by 0x4C8E927: _dl_catch_exception (dl-error-skeleton.c:208)
==63164==    by 0x4015609: _dl_open (dl-open.c:837)
==63164==    by 0x4EB034B: dlopen_doit (dlopen.c:66)
==63164== 
==63164== 208 (16 direct, 192 indirect) bytes in 1 blocks are definitely lost in loss record 17 of 20
==63164==    at 0x483DE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==63164==    by 0x48A8436: ???
==63164==    by 0x48A7815: ???
==63164==    by 0x48A7E41: ???
==63164==    by 0x48A7E7F: ???
==63164==    by 0x4011B99: call_init.part.0 (dl-init.c:72)
==63164==    by 0x4011CA0: call_init (dl-init.c:30)
==63164==    by 0x4011CA0: _dl_init (dl-init.c:119)
==63164==    by 0x4C8E984: _dl_catch_exception (dl-error-skeleton.c:182)
==63164==    by 0x40160CE: dl_open_worker (dl-open.c:758)
==63164==    by 0x4C8E927: _dl_catch_exception (dl-error-skeleton.c:208)
==63164==    by 0x4015609: _dl_open (dl-open.c:837)
==63164==    by 0x4EB034B: dlopen_doit (dlopen.c:66)
==63164== 
==63164== 208 (16 direct, 192 indirect) bytes in 1 blocks are definitely lost in loss record 18 of 20
==63164==    at 0x483DE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==63164==    by 0x48A86CC: ???
==63164==    by 0x48A79C3: ???
==63164==    by 0x48A7E4D: ???
==63164==    by 0x48A7E7F: ???
==63164==    by 0x4011B99: call_init.part.0 (dl-init.c:72)
==63164==    by 0x4011CA0: call_init (dl-init.c:30)
==63164==    by 0x4011CA0: _dl_init (dl-init.c:119)
==63164==    by 0x4C8E984: _dl_catch_exception (dl-error-skeleton.c:182)
==63164==    by 0x40160CE: dl_open_worker (dl-open.c:758)
==63164==    by 0x4C8E927: _dl_catch_exception (dl-error-skeleton.c:208)
==63164==    by 0x4015609: _dl_open (dl-open.c:837)
==63164==    by 0x4EB034B: dlopen_doit (dlopen.c:66)
==63164== 
==63164== 208 (16 direct, 192 indirect) bytes in 1 blocks are definitely lost in loss record 19 of 20
==63164==    at 0x483DE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==63164==    by 0x48A8962: ???
==63164==    by 0x48A7B71: ???
==63164==    by 0x48A7E59: ???
==63164==    by 0x48A7E7F: ???
==63164==    by 0x4011B99: call_init.part.0 (dl-init.c:72)
==63164==    by 0x4011CA0: call_init (dl-init.c:30)
==63164==    by 0x4011CA0: _dl_init (dl-init.c:119)
==63164==    by 0x4C8E984: _dl_catch_exception (dl-error-skeleton.c:182)
==63164==    by 0x40160CE: dl_open_worker (dl-open.c:758)
==63164==    by 0x4C8E927: _dl_catch_exception (dl-error-skeleton.c:208)
==63164==    by 0x4015609: _dl_open (dl-open.c:837)
==63164==    by 0x4EB034B: dlopen_doit (dlopen.c:66)
==63164== 
==63164== 208 (16 direct, 192 indirect) bytes in 1 blocks are definitely lost in loss record 20 of 20
==63164==    at 0x483DE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==63164==    by 0x48A8BF8: ???
==63164==    by 0x48A7D1F: ???
==63164==    by 0x48A7E65: ???
==63164==    by 0x48A7E7F: ???
==63164==    by 0x4011B99: call_init.part.0 (dl-init.c:72)
==63164==    by 0x4011CA0: call_init (dl-init.c:30)
==63164==    by 0x4011CA0: _dl_init (dl-init.c:119)
==63164==    by 0x4C8E984: _dl_catch_exception (dl-error-skeleton.c:182)
==63164==    by 0x40160CE: dl_open_worker (dl-open.c:758)
==63164==    by 0x4C8E927: _dl_catch_exception (dl-error-skeleton.c:208)
==63164==    by 0x4015609: _dl_open (dl-open.c:837)
==63164==    by 0x4EB034B: dlopen_doit (dlopen.c:66)
==63164== 
==63164== LEAK SUMMARY:
==63164==    definitely lost: 80 bytes in 5 blocks
==63164==    indirectly lost: 960 bytes in 15 blocks
==63164==      possibly lost: 0 bytes in 0 blocks
==63164==    still reachable: 0 bytes in 0 blocks
==63164==         suppressed: 0 bytes in 0 blocks
==63164== 
==63164== For lists of detected and suppressed errors, rerun with: -s
==63164== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)

```

</p>
</details>


Signed-off-by: Chen Lihui <lihui.chen@sony.com>

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17373)](https://ci.ros2.org/job/ci_linux/17373/)