### PR TITLE
make sanitizer happy

### DIFF
--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -282,6 +282,23 @@ registerPlugin(const std::string & class_name, const std::string & base_class_na
           break;
         }
       }
+
+      BaseToFactoryMapMap & factory_map_map = getGlobalPluginBaseToFactoryMapMap();
+      bool erase_flag = false;
+      for (auto & factory_map_item : factory_map_map) {
+        FactoryMap & factory_map = factory_map_item.second;
+        for (auto iter = factory_map.begin(); iter != factory_map.end(); ++iter) {
+          if (iter->second == p) {
+            factory_map.erase(iter);
+            erase_flag = true;
+            break;
+          }
+        }
+        if (erase_flag) {
+          break;
+        }
+      }
+
       getPluginBaseToFactoryMapMapMutex().unlock();
 
 #ifndef _WIN32

--- a/include/class_loader/multi_library_class_loader.hpp
+++ b/include/class_loader/multi_library_class_loader.hpp
@@ -56,7 +56,7 @@ namespace class_loader
 {
 
 typedef std::string LibraryPath;
-typedef std::map<LibraryPath, std::shared_ptr<class_loader::ClassLoader>> LibraryToClassLoaderMap;
+typedef std::map<LibraryPath, class_loader::ClassLoader *> LibraryToClassLoaderMap;
 typedef std::vector<ClassLoader *> ClassLoaderVector;
 
 class MultiLibraryClassLoaderImpl;
@@ -355,7 +355,7 @@ private:
    */
   void shutdownAllClassLoaders();
 
-  bool enable_ondemand_loadunload_;
+  MultiLibraryClassLoaderImpl * impl_;
 };
 
 

--- a/include/class_loader/multi_library_class_loader.hpp
+++ b/include/class_loader/multi_library_class_loader.hpp
@@ -56,7 +56,7 @@ namespace class_loader
 {
 
 typedef std::string LibraryPath;
-typedef std::map<LibraryPath, class_loader::ClassLoader *> LibraryToClassLoaderMap;
+typedef std::map<LibraryPath, std::shared_ptr<class_loader::ClassLoader>> LibraryToClassLoaderMap;
 typedef std::vector<ClassLoader *> ClassLoaderVector;
 
 class MultiLibraryClassLoaderImpl;
@@ -355,7 +355,7 @@ private:
    */
   void shutdownAllClassLoaders();
 
-  MultiLibraryClassLoaderImpl * impl_;
+  bool enable_ondemand_loadunload_;
 };
 
 

--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -117,10 +117,10 @@ int ClassLoader::unloadLibrary()
 
 int ClassLoader::unloadLibraryInternal(bool lock_plugin_ref_count)
 {
-  std::lock_guard<std::recursive_mutex> load_ref_lock(load_ref_count_mutex_);
   if (lock_plugin_ref_count) {
     plugin_ref_count_mutex_.lock();
   }
+  std::lock_guard<std::recursive_mutex> load_ref_lock(load_ref_count_mutex_);
 
   try {
     if (plugin_ref_count_ > 0) {

--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -521,9 +521,12 @@ void unloadLibrary(const std::string & library_path, ClassLoader * loader)
         throw class_loader::LibraryUnloadException(
                 "Could not unload library (rcpputils exception = " + std::string(e.what()) + ")");
       }
+    } else {
+      CONSOLE_BRIDGE_logDebug(
+        "class_loader.impl: "
+        "Attempt to unload library %s that class_loader is unaware of or is already unloaded",
+        library_path.c_str());
     }
-    throw class_loader::LibraryUnloadException(
-            "Attempt to unload library that class_loader is unaware of.");
   }
 }
 

--- a/src/multi_library_class_loader.cpp
+++ b/src/multi_library_class_loader.cpp
@@ -37,7 +37,24 @@
 namespace class_loader
 {
 
-class MultiLibraryClassLoaderImpl
+class ClassLoaderDependency
+{
+protected:
+  ClassLoaderDependency()
+  {
+    // make the static variable in `ClassLoader` destroyed after `active_class_loaders_`
+    class_loader::impl::getLoadedLibraryVectorMutex();
+    class_loader::impl::getPluginBaseToFactoryMapMapMutex();
+    class_loader::impl::getGlobalPluginBaseToFactoryMapMap();
+    class_loader::impl::getMetaObjectGraveyard();
+    class_loader::impl::getLoadedLibraryVector();
+    class_loader::impl::getCurrentlyLoadingLibraryName();
+    class_loader::impl::getCurrentlyActiveClassLoader();
+    class_loader::impl::hasANonPurePluginLibraryBeenOpened();
+  }
+};
+
+class MultiLibraryClassLoaderImpl : public ClassLoaderDependency
 {
 public:
   LibraryToClassLoaderMap active_class_loaders_;

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -94,9 +94,6 @@ TEST(ClassLoaderUniquePtrTest, basicLoadFailures) {
   EXPECT_THROW(
     class_loader::impl::loadLibrary("LIBRARY_1", &loader1),
     class_loader::LibraryLoadException);
-  EXPECT_THROW(
-    class_loader::impl::unloadLibrary("LIBRARY_1", &loader1),
-    class_loader::LibraryUnloadException);
 }
 
 TEST(ClassLoaderUniquePtrTest, MultiLibraryClassLoaderFailures) {

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -121,9 +121,6 @@ TEST(ClassLoaderUniquePtrTest, basicLoadFailures) {
   EXPECT_THROW(
     class_loader::impl::loadLibrary("LIBRARY_1", &loader1),
     class_loader::LibraryLoadException);
-  EXPECT_THROW(
-    class_loader::impl::unloadLibrary("LIBRARY_1", &loader1),
-    class_loader::LibraryUnloadException);
 }
 
 TEST(ClassLoaderUniquePtrTest, MultiLibraryClassLoaderFailures) {


### PR DESCRIPTION
related to https://github.com/ros/class_loader/pull/201#issuecomment-1287109359

The [CI logs](https://github.com/tylerjw/class_loader/actions/runs/3298507574/jobs/5440716254) will be expired in the future and might no longer be available, so I copy the log as follows,

<details><summary> MultiLibraryClassLoader memory leak </summary>
<p>

```shell
    ==6769==ERROR: LeakSanitizer: detected memory leaks
    
    Direct leak of 144 byte(s) in 1 object(s) allocated from:
        #0 0x7efc617811c7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
        #1 0x7efc616bac16 in class_loader::MultiLibraryClassLoader::loadLibrary(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/target_ws/src/class_loader/src/multi_library_class_loader.cpp:96
        #2 0x56419df31a12 in MultiClassLoaderTest_noWarningOnLazyLoad_Test::TestBody() /root/target_ws/src/class_loader/test/utest.cpp:380
        #3 0x56419df88576 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2433
        #4 0x56419df8129e in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2469
        #5 0x56419df5b755 in testing::Test::Run() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2508
        #6 0x56419df5c19a in testing::TestInfo::Run() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2684
        #7 0x56419df5c8fb in testing::TestSuite::Run() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2816
        #8 0x56419df68f10 in testing::internal::UnitTestImpl::RunAllTests() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:5338
        #9 0x56419df89a68 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2433
        #10 0x56419df824b2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2469
        #11 0x56419df676f2 in testing::UnitTest::Run() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:4925
        #12 0x56419df3871f in RUN_ALL_TESTS() (/root/target_ws/build/class_loader/test/class_loader_utest+0x3271f)
        #13 0x56419df33fe6 in main /root/target_ws/src/class_loader/test/utest.cpp:448
        #14 0x7efc6110fd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    
    Direct leak of 144 byte(s) in 1 object(s) allocated from:
        #0 0x7efc617811c7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
        #1 0x7efc616bac16 in class_loader::MultiLibraryClassLoader::loadLibrary(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/target_ws/src/class_loader/src/multi_library_class_loader.cpp:96
        #2 0x56419df31a2b in MultiClassLoaderTest_noWarningOnLazyLoad_Test::TestBody() /root/target_ws/src/class_loader/test/utest.cpp:381
        #3 0x56419df88576 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2433
        #4 0x56419df8129e in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2469
        #5 0x56419df5b755 in testing::Test::Run() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2508
        #6 0x56419df5c19a in testing::TestInfo::Run() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2684
        #7 0x56419df5c8fb in testing::TestSuite::Run() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2816
        #8 0x56419df68f10 in testing::internal::UnitTestImpl::RunAllTests() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:5338
        #9 0x56419df89a68 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2433
        #10 0x56419df824b2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2469
        #11 0x56419df676f2 in testing::UnitTest::Run() /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:4925
        #12 0x56419df3871f in RUN_ALL_TESTS() (/root/target_ws/build/class_loader/test/class_loader_utest+0x3271f)
        #13 0x56419df33fe6 in main /root/target_ws/src/class_loader/test/utest.cpp:448
        #14 0x7efc6110fd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    
    Indirect leak of 64 byte(s) in 2 object(s) allocated from:
        #0 0x7efc617811c7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
        #1 0x7efc61563ad9 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) (/lib/x86_64-linux-gnu/libstdc++.so.6+0x14ead9)
    
    SUMMARY: AddressSanitizer: 352 byte(s) leaked in 4 allocation(s).

```

</p>
</details>


<details><summary> potential dead lock  </summary>
<p>

```shell
    WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=7271)
      Cycle in lock order graph: M98 (0x7b24000001e8) => M99 (0x7b2400000218) => M98
    
      Mutex M99 acquired here while holding mutex M98 in main thread:
        #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
        #1 __gthread_mutex_lock(pthread_mutex_t*) <null> (class_loader_unique_ptr_test+0x1d1ff)
        #2 __gthread_recursive_mutex_lock(pthread_mutex_t*) <null> (class_loader_unique_ptr_test+0x1d283)
        #3 std::recursive_mutex::lock() <null> (class_loader_unique_ptr_test+0x1d852)
        #4 class_loader::ClassLoader::unloadLibraryInternal(bool) /root/target_ws/src/class_loader/src/class_loader.cpp:122 (libclass_loader.so+0x37513)
        #5 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2433 (class_loader_unique_ptr_test+0x64238)
        #6 main /root/target_ws/src/class_loader/test/unique_ptr_test.cpp:295 (class_loader_unique_ptr_test+0x1baf8)
    
        Hint: use TSAN_OPTIONS=second_deadlock_stack=1 to get more informative warning message
    
      Mutex M98 acquired here while holding mutex M99 in main thread:
        #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
        #1 __gthread_mutex_lock(pthread_mutex_t*) <null> (class_loader_unique_ptr_test+0x1d1ff)
        #2 __gthread_recursive_mutex_lock(pthread_mutex_t*) <null> (class_loader_unique_ptr_test+0x1d283)
        #3 std::recursive_mutex::lock() <null> (class_loader_unique_ptr_test+0x1d852)
        #4 std::lock_guard<std::recursive_mutex>::lock_guard(std::recursive_mutex&) <null> (class_loader_unique_ptr_test+0x22be4)
        #5 class_loader::ClassLoader::unloadLibraryInternal(bool) /root/target_ws/src/class_loader/src/class_loader.cpp:120 (libclass_loader.so+0x374fd)
        #6 void std::__invoke_impl<void, void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*>(std::__invoke_memfun_deref, void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*&&) <null> (class_loader_unique_ptr_test+0x2b939)
        #7 std::__invoke_result<void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*>::type std::__invoke<void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*>(void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*&&) <null> (class_loader_unique_ptr_test+0x2ad29)
        #8 void std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>::__call<void, Base*&&, 0ul, 1ul>(std::tuple<Base*&&>&&, std::_Index_tuple<0ul, 1ul>) <null> (class_loader_unique_ptr_test+0x29efd)
        #9 void std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>::operator()<Base*, void>(Base*&&) <null> (class_loader_unique_ptr_test+0x286fe)
        #10 void std::__invoke_impl<void, std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*>(std::__invoke_other, std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*&&) <null> (class_loader_unique_ptr_test+0x26557)
        #11 std::enable_if<std::__and_<std::is_void<void>, std::__is_invocable<std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*> >::value, void>::type std::__invoke_r<void, std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*>(std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*&&) <null> (class_loader_unique_ptr_test+0x24783)
        #12 std::_Function_handler<void (Base*), std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)> >::_M_invoke(std::_Any_data const&, Base*&&) <null> (class_loader_unique_ptr_test+0x22def)
        #13 std::function<void (Base*)>::operator()(Base*) const <null> (class_loader_unique_ptr_test+0x2118c)
        #14 std::unique_ptr<Base, std::function<void (Base*)> >::~unique_ptr() <null> (class_loader_unique_ptr_test+0x1efe8)
        #15 MultiClassLoaderUniquePtrTest_noWarningOnLazyLoad_Test::TestBody() /root/target_ws/src/class_loader/test/unique_ptr_test.cpp:284 (class_loader_unique_ptr_test+0x1b76e)
        #16 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2433 (class_loader_unique_ptr_test+0x64238)
        #17 main /root/target_ws/src/class_loader/test/unique_ptr_test.cpp:295 (class_loader_unique_ptr_test+0x1baf8)
    
    SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock) (/root/target_ws/build/class_loader/test/class_loader_unique_ptr_test+0x1d1ff) in __gthread_mutex_lock(pthread_mutex_t*)
    ==================
    ==================
    WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=7271)
      Cycle in lock order graph: M96 (0x7b24000000c8) => M97 (0x7b24000000f8) => M96
    
      Mutex M97 acquired here while holding mutex M96 in main thread:
        #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
        #1 __gthread_mutex_lock(pthread_mutex_t*) <null> (class_loader_unique_ptr_test+0x1d1ff)
        #2 __gthread_recursive_mutex_lock(pthread_mutex_t*) <null> (class_loader_unique_ptr_test+0x1d283)
        #3 std::recursive_mutex::lock() <null> (class_loader_unique_ptr_test+0x1d852)
        #4 class_loader::ClassLoader::unloadLibraryInternal(bool) /root/target_ws/src/class_loader/src/class_loader.cpp:122 (libclass_loader.so+0x37513)
        #5 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2433 (class_loader_unique_ptr_test+0x64238)
        #6 main /root/target_ws/src/class_loader/test/unique_ptr_test.cpp:295 (class_loader_unique_ptr_test+0x1baf8)
    
        Hint: use TSAN_OPTIONS=second_deadlock_stack=1 to get more informative warning message
    
      Mutex M96 acquired here while holding mutex M97 in main thread:
        #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
        #1 __gthread_mutex_lock(pthread_mutex_t*) <null> (class_loader_unique_ptr_test+0x1d1ff)
        #2 __gthread_recursive_mutex_lock(pthread_mutex_t*) <null> (class_loader_unique_ptr_test+0x1d283)
        #3 std::recursive_mutex::lock() <null> (class_loader_unique_ptr_test+0x1d852)
        #4 std::lock_guard<std::recursive_mutex>::lock_guard(std::recursive_mutex&) <null> (class_loader_unique_ptr_test+0x22be4)
        #5 class_loader::ClassLoader::unloadLibraryInternal(bool) /root/target_ws/src/class_loader/src/class_loader.cpp:120 (libclass_loader.so+0x374fd)
        #6 void std::__invoke_impl<void, void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*>(std::__invoke_memfun_deref, void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*&&) <null> (class_loader_unique_ptr_test+0x2b939)
        #7 std::__invoke_result<void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*>::type std::__invoke<void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*>(void (class_loader::ClassLoader::*&)(Base*), class_loader::ClassLoader*&, Base*&&) <null> (class_loader_unique_ptr_test+0x2ad29)
        #8 void std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>::__call<void, Base*&&, 0ul, 1ul>(std::tuple<Base*&&>&&, std::_Index_tuple<0ul, 1ul>) <null> (class_loader_unique_ptr_test+0x29efd)
        #9 void std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>::operator()<Base*, void>(Base*&&) <null> (class_loader_unique_ptr_test+0x286fe)
        #10 void std::__invoke_impl<void, std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*>(std::__invoke_other, std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*&&) <null> (class_loader_unique_ptr_test+0x26557)
        #11 std::enable_if<std::__and_<std::is_void<void>, std::__is_invocable<std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*> >::value, void>::type std::__invoke_r<void, std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*>(std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)>&, Base*&&) <null> (class_loader_unique_ptr_test+0x24783)
        #12 std::_Function_handler<void (Base*), std::_Bind<void (class_loader::ClassLoader::*(class_loader::ClassLoader*, std::_Placeholder<1>))(Base*)> >::_M_invoke(std::_Any_data const&, Base*&&) <null> (class_loader_unique_ptr_test+0x22def)
        #13 std::function<void (Base*)>::operator()(Base*) const <null> (class_loader_unique_ptr_test+0x2118c)
        #14 std::unique_ptr<Base, std::function<void (Base*)> >::~unique_ptr() <null> (class_loader_unique_ptr_test+0x1efe8)
        #15 MultiClassLoaderUniquePtrTest_noWarningOnLazyLoad_Test::TestBody() /root/target_ws/src/class_loader/test/unique_ptr_test.cpp:284 (class_loader_unique_ptr_test+0x1b78c)
        #16 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /opt/ros/rolling/src/gtest_vendor/./src/gtest.cc:2433 (class_loader_unique_ptr_test+0x64238)
        #17 main /root/target_ws/src/class_loader/test/unique_ptr_test.cpp:295 (class_loader_unique_ptr_test+0x1baf8)
    
    SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock)

```

</p>
</details>


Signed-off-by: Chen Lihui <lihui.chen@sony.com>