### PR TITLE
Resolve symlinks fully before loading the library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(Boost REQUIRED COMPONENTS thread system)
+find_package(Boost REQUIRED COMPONENTS thread system filesystem)
 
 set(CATKIN_DISABLED false CACHE BOOL "Disable the catkin build, useful if catkin is present but a build outside of ros is done")
 if(NOT CATKIN_DISABLED)


### PR DESCRIPTION
Relates to https://github.com/ros/ros/pull/309.

Our Nix-based ros builds create a directory that has each ros package symlinked, so instead of one directory holding all our ros packages, we have one directory holding symlinks to the ros packages. The package `move_base` would exist in `/nix/store/<hash>-sdk/merged/move_base/move_base`, but `/nix/store/<hash>-sdk/merged/move_base/` would be a symlink to `/nix/store/<hash>-move_base/`.

For plugins, they could be found in `/nix/store/<hash>-sdk/merged/my_package/libmy_plugin.so`, but `/nix/store/<hash>-sdk/merged/my_package/` would be a symlink to `/nix/store/<hash>-my_package/`.

Without resolving symlinks, core dumps would contain library paths to the full `/nix/store/<hash>-sdk/merged/my_package/libmy_plugin.so` path, which requires developers to download that completely. If we resolve the symlinks just before loading the plugin developers only need `/nix/store/<hash>-my_package/` at that particular version.

fyi @mikepurvis , @jasonimercer