### PR TITLE
[ROS-O] declare newly-required boost filesystem component

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
 
   <depend>libboost-thread-dev</depend>
   <depend>libboost-system-dev</depend>
+  <depend>libboost-filesystem-dev</depend>
   <depend>libconsole-bridge-dev</depend>
   <depend>libpoco-dev</depend>
 </package>


### PR DESCRIPTION
Oversight in https://github.com/ros/class_loader/pull/207 . No idea how this was never noticed.