### PR TITLE
Remove all uses of ament_target_dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,19 +31,18 @@ if(ament_cmake_FOUND)
   ament_export_dependencies(rcpputils)
 endif()
 
-set(${PROJECT_NAME}_SRCS
+add_library(${PROJECT_NAME} ${explicit_library_type}
   src/class_loader.cpp
   src/class_loader_core.cpp
   src/meta_object.cpp
   src/multi_library_class_loader.cpp
 )
-add_library(${PROJECT_NAME} ${explicit_library_type} ${${PROJECT_NAME}_SRCS})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 if(ament_cmake_FOUND)
-  target_link_libraries(${PROJECT_NAME}
+  target_link_libraries(${PROJECT_NAME} PUBLIC
     console_bridge::console_bridge
     rcpputils::rcpputils)
   ament_export_targets(${PROJECT_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,40 +3,16 @@ find_package(ament_cmake_gtest REQUIRED)
 include("../cmake/class_loader_hide_library_symbols.cmake")
 
 add_library(${PROJECT_NAME}_TestPlugins1 EXCLUDE_FROM_ALL SHARED plugins1.cpp)
-if(ament_cmake_FOUND)
-  target_include_directories(${PROJECT_NAME}_TestPlugins1
-    PUBLIC "../include")
-  ament_target_dependencies(${PROJECT_NAME}_TestPlugins1 "console_bridge")
-else()
-  target_include_directories(${PROJECT_NAME}_TestPlugins1
-    PUBLIC "../include" ${console_bridge_INCLUDE_DIRS})
-endif()
 target_link_libraries(${PROJECT_NAME}_TestPlugins1 ${PROJECT_NAME})
 class_loader_hide_library_symbols(${PROJECT_NAME}_TestPlugins1)
 
 add_library(${PROJECT_NAME}_TestPlugins2 EXCLUDE_FROM_ALL SHARED plugins2.cpp)
-if(ament_cmake_FOUND)
-  target_include_directories(${PROJECT_NAME}_TestPlugins2
-    PUBLIC "../include")
-  ament_target_dependencies(${PROJECT_NAME}_TestPlugins2 "console_bridge")
-else()
-  target_include_directories(${PROJECT_NAME}_TestPlugins2
-    PUBLIC "../include" ${console_bridge_INCLUDE_DIRS})
-endif()
 target_link_libraries(${PROJECT_NAME}_TestPlugins2 ${PROJECT_NAME})
 class_loader_hide_library_symbols(${PROJECT_NAME}_TestPlugins2)
 
 # These plugins are loaded using dlopen() with RTLD_GLOBAL in utest and may cause side effects
 # in other tests if they are used elsewhere.
 add_library(${PROJECT_NAME}_TestGlobalPlugins EXCLUDE_FROM_ALL SHARED global_plugins.cpp)
-if(ament_cmake_FOUND)
-  target_include_directories(${PROJECT_NAME}_TestGlobalPlugins
-    PUBLIC "../include")
-  ament_target_dependencies(${PROJECT_NAME}_TestGlobalPlugins "console_bridge")
-else()
-  target_include_directories(${PROJECT_NAME}_TestGlobalPlugins
-    PUBLIC "../include" ${console_bridge_INCLUDE_DIRS})
-endif()
 target_link_libraries(${PROJECT_NAME}_TestGlobalPlugins ${PROJECT_NAME})
 class_loader_hide_library_symbols(${PROJECT_NAME}_TestGlobalPlugins)
 
@@ -51,15 +27,6 @@ ament_add_gtest(${PROJECT_NAME}_utest utest.cpp
 )
 
 if(TARGET ${PROJECT_NAME}_utest)
-  if(ament_cmake_FOUND)
-    target_include_directories(${PROJECT_NAME}_utest
-      PUBLIC "../include")
-    ament_target_dependencies(${PROJECT_NAME}_utest "console_bridge")
-  else()
-    target_include_directories(${PROJECT_NAME}_utest
-      PUBLIC "../include" ${console_bridge_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME}_utest)
-  endif()
   target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
   if(NOT WIN32)
     target_link_libraries(${PROJECT_NAME}_utest pthread)
@@ -74,15 +41,6 @@ ament_add_gtest(${PROJECT_NAME}_unique_ptr_test unique_ptr_test.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}"
 )
 if(TARGET ${PROJECT_NAME}_unique_ptr_test)
-  if(ament_cmake_FOUND)
-    target_include_directories(${PROJECT_NAME}_unique_ptr_test
-      PUBLIC "../include")
-    ament_target_dependencies(${PROJECT_NAME}_unique_ptr_test)
-  else()
-    target_include_directories(${PROJECT_NAME}_unique_ptr_test
-      PUBLIC "../include")
-    target_link_libraries(${PROJECT_NAME}_unique_ptr_test)
-  endif()
   target_link_libraries(${PROJECT_NAME}_unique_ptr_test ${PROJECT_NAME})
   if(NOT WIN32)
     target_link_libraries(${PROJECT_NAME}_unique_ptr_test pthread)

--- a/test/fviz_case_study/CMakeLists.txt
+++ b/test/fviz_case_study/CMakeLists.txt
@@ -7,21 +7,11 @@ endif()
 
 # This "fviz_main" is just for testing locally, for the test see "fviz_test" below.
 add_executable(${PROJECT_NAME}_Test_Fviz_Main EXCLUDE_FROM_ALL fviz_main.cpp)
-if(ament_cmake_FOUND)
-  target_include_directories(${PROJECT_NAME}_Test_Fviz_Main
-    PUBLIC "../include")
-  ament_target_dependencies(${PROJECT_NAME}_Test_Fviz_Main "console_bridge")
-else()
-  target_include_directories(${PROJECT_NAME}_Test_Fviz_Main
-    PUBLIC "../include" ${console_bridge_INCLUDE_DIRS})
-endif()
 target_link_libraries(${PROJECT_NAME}_Test_Fviz_Main
   ${PROJECT_NAME} ${PROJECT_NAME}_Test_Fviz)
 
 add_library(${PROJECT_NAME}_Test_FvizDefaultPlugin
   EXCLUDE_FROM_ALL SHARED fviz_default_plugin.cpp)
-target_include_directories(${PROJECT_NAME}_Test_FvizDefaultPlugin
-  PUBLIC "../include" ${console_bridge_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME}_Test_FvizDefaultPlugin
   ${PROJECT_NAME} ${PROJECT_NAME}_Test_Fviz)
 class_loader_hide_library_symbols(${PROJECT_NAME}_Test_FvizDefaultPlugin)
@@ -36,15 +26,6 @@ ament_add_gtest(${PROJECT_NAME}_fviz_test fviz_test.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}"
 )
 if(TARGET ${PROJECT_NAME}_fviz_test)
-  if(ament_cmake_FOUND)
-    target_include_directories(${PROJECT_NAME}_fviz_test
-      PUBLIC "../include")
-    ament_target_dependencies(${PROJECT_NAME}_fviz_test "console_bridge")
-  else()
-    target_include_directories(${PROJECT_NAME}_fviz_test
-      PUBLIC "../include" ${console_bridge_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME}_fviz_test)
-  endif()
   target_link_libraries(${PROJECT_NAME}_fviz_test
     ${PROJECT_NAME} ${PROJECT_NAME}_Test_Fviz)
   if(NOT WIN32)


### PR DESCRIPTION
We can just use target_link_libraries instead.