### PR TITLE
suppress sanitizer warning about (expected) leak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ install(TARGETS ${PROJECT_NAME}
 install(DIRECTORY include/class_loader/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-install(PROGRAMS scripts/class_loader_headers_update.py
+catkin_install_python(PROGRAMS scripts/class_loader_headers_update.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -163,6 +163,15 @@ bool hasANonPurePluginLibraryBeenOpened();
 CLASS_LOADER_PUBLIC
 void hasANonPurePluginLibraryBeenOpened(bool hasIt);
 
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer) // for clang
+#define __SANITIZE_ADDRESS__         // GCC already sets this
+#endif
+#endif
+
+#if defined(__SANITIZE_ADDRESS__)
+#include <sanitizer/lsan_interface.h>
+#endif
 // Plugin Functions
 
 /**
@@ -207,6 +216,11 @@ void registerPlugin(const std::string & class_name, const std::string & base_cla
   // Create factory
   impl::AbstractMetaObject<Base> * new_factory =
     new impl::MetaObject<Derived, Base>(class_name, base_class_name);
+
+#if defined(__SANITIZE_ADDRESS__)
+  __lsan_ignore_object(new_factory);
+#endif
+
   new_factory->addOwningClassLoader(getCurrentlyActiveClassLoader());
   new_factory->setAssociatedLibraryPath(getCurrentlyLoadingLibraryName());
 

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -217,7 +217,7 @@ void registerPlugin(const std::string & class_name, const std::string & base_cla
   if (factoryMap.find(class_name) != factoryMap.end()) {
     CONSOLE_BRIDGE_logWarn(
       "class_loader.impl: SEVERE WARNING!!! "
-      "A namespace collision has occured with plugin factory for class %s. "
+      "A namespace collision has occurred with plugin factory for class %s. "
       "New factory will OVERWRITE existing one. "
       "This situation occurs when libraries containing plugins are directly linked against an "
       "executable (the one running right now generating this message). "

--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,8 @@
   <description>
     The class_loader package is a ROS-independent package for loading plugins during runtime and the foundation of the higher level ROS "pluginlib" library. class_loader utilizes the host operating system's runtime loader to open runtime libraries (e.g. .so/.dll files), introspect the library for exported plugin classes, and allows users to instantiate objects of said exported classes without the explicit declaration (i.e. header file) for those classes.
   </description>
-  <maintainer email="stevenragnarok@osrfoundation.org">Steven! Ragnarök</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="geoff@openrobotics.org">Geoffrey Biggs</maintainer>
   <license>BSD</license>
 
   <url type="website">http://ros.org/wiki/class_loader</url>
@@ -14,6 +15,7 @@
   <url type="repository">https://github.com/ros/class_loader</url>
 
   <author>Mirza Shah</author>
+  <author email="stevenragnarok@openrobotics.org">Steven! Ragnarök</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 


### PR DESCRIPTION
to address https://github.com/ros/class_loader/issues/131, this didn't change code, instead it suppress the sanitizer report because we know this leak is expected. this suppression can't be done through runtime suppression file because sanitizer can't do that for dlopen shared libraries https://github.com/google/sanitizers/issues/89 , so better to annotate it. 