### PR TITLE
Took into account of the reference of unmanaged instances

### DIFF
--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -327,10 +327,8 @@ private:
     Base * obj = class_loader::impl::createInstance<Base>(derived_class_name, this);
     assert(obj != NULL);  // Unreachable assertion if createInstance() throws on failure.
 
-    if (managed) {
-      std::lock_guard<std::recursive_mutex> lock(plugin_ref_count_mutex_);
-      ++plugin_ref_count_;
-    }
+    std::lock_guard<std::recursive_mutex> lock(plugin_ref_count_mutex_);
+    ++plugin_ref_count_;
 
     return obj;
   }


### PR DESCRIPTION
Adresses : #218 
I have increased `plugin_ref_count_` even when unmanaged instances is created. `plugin_ref_count_` is only changed inside `onPluginDeletion` function and `createRawInstance`.  `onPluginDeletion` is not executed for unmanaged raw instances. Thus, when plugin loader is deleted, shared library is not unloaded. In main branch, it directly unloads library in case only `createUnmanagedInstance`  method is used as seen in the example in addressed issue.

I have also debugged with valgrind and it has below results.

My PR : https://gist.githubusercontent.com/DarkusAlphaHydranoid/7bde368143c6844ec427159e300cb2fc/raw/0ccecc5e9716fd85d315fc970c9724f96231424f/valgrind_log_class_loader_pr_217.txt

Your main branch: https://gist.githubusercontent.com/DarkusAlphaHydranoid/7bde368143c6844ec427159e300cb2fc/raw/0ccecc5e9716fd85d315fc970c9724f96231424f/valgrind_log_class_loader_commit_464fd14.txt

Looks like my branch has less memory leak.