### PR TITLE
Add support for passing arguments to constructors

### DIFF
--- a/include/class_loader/class_loader.hpp
+++ b/include/class_loader/class_loader.hpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 // TODO(mikaelarguedas) remove this once console_bridge complies with this
@@ -119,13 +120,16 @@ public:
    * if the library is not yet loaded (which typically happens when in "On Demand Load/Unload" mode).
    *
    * @param derived_class_name The name of the class we want to create (@see getAvailableClasses())
+   * @param args Arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return A std::shared_ptr<Base> to newly created plugin object
    */
-  template<class Base>
-  std::shared_ptr<Base> createInstance(const std::string & derived_class_name)
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+  std::shared_ptr<Base> createInstance(const std::string & derived_class_name, Args &&... args)
   {
     return std::shared_ptr<Base>(
-      createRawInstance<Base>(derived_class_name, true),
+      createRawInstance<Base>(derived_class_name, true, std::forward<Args>(args)...),
       std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)
     );
   }
@@ -141,12 +145,15 @@ public:
    *
    * @param derived_class_name
    *   The name of the class we want to create (@see getAvailableClasses()).
+   * @param args Arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return A std::unique_ptr<Base> to newly created plugin object.
    */
-  template<class Base>
-  UniquePtr<Base> createUniqueInstance(const std::string & derived_class_name)
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+  UniquePtr<Base> createUniqueInstance(const std::string & derived_class_name, Args &&... args)
   {
-    Base * raw = createRawInstance<Base>(derived_class_name, true);
+    Base * raw = createRawInstance<Base>(derived_class_name, true, std::forward<Args>(args)...);
     return std::unique_ptr<Base, DeleterType<Base>>(
       raw,
       std::bind(&ClassLoader::onPluginDeletion<Base>, this, std::placeholders::_1)
@@ -164,12 +171,15 @@ public:
    *
    * @param derived_class_name
    *   The name of the class we want to create (@see getAvailableClasses()).
+   * @param args Arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return An unmanaged (i.e. not a shared_ptr) Base* to newly created plugin object.
    */
-  template<class Base>
-  Base * createUnmanagedInstance(const std::string & derived_class_name)
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+  Base * createUnmanagedInstance(const std::string & derived_class_name, Args &&... args)
   {
-    return createRawInstance<Base>(derived_class_name, false);
+    return createRawInstance<Base>(derived_class_name, false, std::forward<Args>(args)...);
   }
 
   /**
@@ -297,10 +307,13 @@ private:
    * @param managed
    *   If true, the returned pointer is assumed to be wrapped in a smart
    *   pointer by the caller.
+   * @param args Arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return A Base* to newly created plugin object.
    */
-  template<class Base>
-  Base * createRawInstance(const std::string & derived_class_name, bool managed)
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+  Base * createRawInstance(const std::string & derived_class_name, bool managed, Args &&... args)
   {
     if (!managed) {
       this->setUnmanagedInstanceBeenCreated(true);
@@ -324,7 +337,8 @@ private:
       loadLibrary();
     }
 
-    Base * obj = class_loader::impl::createInstance<Base>(derived_class_name, this);
+    Base * obj = class_loader::impl::createInstance<Base>(derived_class_name, this,
+        std::forward<Args>(args)...);
     assert(obj != NULL);  // Unreachable assertion if createInstance() throws on failure.
 
     if (managed) {

--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -55,6 +55,7 @@
 #endif
 
 #include "class_loader/exceptions.hpp"
+#include "class_loader/interface_traits.hpp"
 #include "class_loader/meta_object.hpp"
 #include "class_loader/visibility_control.hpp"
 
@@ -344,10 +345,13 @@ registerPlugin(const std::string & class_name, const std::string & base_class_na
  *
  * @param derived_class_name - The name of the derived class (unmangled)
  * @param loader - The ClassLoader whose scope we are within
+ * @param args - Arguments for the constructor of the derived class (types defined
+ * by InterfaceTraits of the Base class)
  * @return A pointer to newly created plugin, note caller is responsible for object destruction
  */
-template<typename Base>
-Base * createInstance(const std::string & derived_class_name, ClassLoader * loader)
+template<typename Base, class ... Args,
+  std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+Base * createInstance(const std::string & derived_class_name, ClassLoader * loader, Args &&... args)
 {
   AbstractMetaObject<Base> * factory = nullptr;
 
@@ -363,28 +367,26 @@ Base * createInstance(const std::string & derived_class_name, ClassLoader * load
 
   Base * obj = nullptr;
   if (factory != nullptr && factory->isOwnedBy(loader)) {
-    obj = factory->create();
+    obj = factory->create(std::forward<Args>(args)...);
+  } else if (factory && factory->isOwnedBy(nullptr)) {
+    CONSOLE_BRIDGE_logDebug(
+      "%s",
+      "class_loader.impl: ALERT!!! "
+      "A metaobject (i.e. factory) exists for desired class, but has no owner. "
+      "This implies that the library containing the class was dlopen()ed by means other than "
+      "through the class_loader interface. "
+      "This can happen if you build plugin libraries that contain more than just plugins "
+      "(i.e. normal code your app links against) -- that intrinsically will trigger a dlopen() "
+      "prior to main(). "
+      "You should isolate your plugins into their own library, otherwise it will not be "
+      "possible to shutdown the library!");
+
+    obj = factory->create(std::forward<Args>(args)...);
   }
 
   if (nullptr == obj) {  // Was never created
-    if (factory && factory->isOwnedBy(nullptr)) {
-      CONSOLE_BRIDGE_logDebug(
-        "%s",
-        "class_loader.impl: ALERT!!! "
-        "A metaobject (i.e. factory) exists for desired class, but has no owner. "
-        "This implies that the library containing the class was dlopen()ed by means other than "
-        "through the class_loader interface. "
-        "This can happen if you build plugin libraries that contain more than just plugins "
-        "(i.e. normal code your app links against) -- that intrinsically will trigger a dlopen() "
-        "prior to main(). "
-        "You should isolate your plugins into their own library, otherwise it will not be "
-        "possible to shutdown the library!");
-
-      obj = factory->create();
-    } else {
-      throw class_loader::CreateClassException(
-              "Could not create instance of type " + derived_class_name);
-    }
+    throw class_loader::CreateClassException(
+            "Could not create instance of type " + derived_class_name);
   }
 
   CONSOLE_BRIDGE_logDebug(

--- a/include/class_loader/interface_traits.hpp
+++ b/include/class_loader/interface_traits.hpp
@@ -37,6 +37,17 @@
 namespace class_loader
 {
 
+namespace impl
+{
+
+template<class ...>
+constexpr bool false_v = false;
+
+}  // namespace impl
+
+template<class ... Params>
+struct ConstructorParameters {};
+
 /**
  * @brief Customization point that allows setting additional properties of
  * an interface class.
@@ -50,14 +61,14 @@ namespace class_loader
  * specified.
  *
  * Supported properties:
- * - `constructor_signature` (member type)
- *   - accessor: interface_constructor_signature
- *   - default: T()
- *   - defines the signature with which will the class loader instantiate the
+ * - `constructor_parameters` (member type)
+ *   - accessor: interface_constructor_parameters
+ *   - default: ConstructorParameters<>
+ *   - defines the parameters with which will the class loader instantiate the
  *     derived classes
  *   - example:
  *     \code
- *     using constructor_signature = T(double, int);
+ *     using constructor_parameters = ConstructorParameters<double, int>;
  *     \endcode
  *     defines that derived classes of class T (replace with the base class type
  *     used in this specialization) will be instantiated with `double` and `int`
@@ -80,7 +91,7 @@ namespace class_loader
  * struct class_loader::InterfaceTraits<BaseWithInterfaceCtor>
  * {
  *   // derived classes will be instantiated with two parameters (string and unique_ptr<int>)
- *   using constructor_signature = BaseWithInterfaceCtor(std::string, std::unique_ptr<int>);
+ *   using constructor_parameters = ConstructorParameters<std::string, std::unique_ptr<int>>;
  * };
  * \endcode
  */
@@ -93,46 +104,63 @@ namespace impl
 {
 
 template<class T, class = void>
-struct interface_constructor_signature_impl
+struct interface_constructor_parameters_impl
 {
-  using type = T();
+  using type = ConstructorParameters<>;
 };
 
 template<class T>
-struct interface_constructor_signature_impl<T,
-  std::void_t<typename InterfaceTraits<T>::constructor_signature>>
+struct interface_constructor_parameters_impl<T,
+  std::void_t<typename InterfaceTraits<T>::constructor_parameters>>
 {
-  using type = typename InterfaceTraits<T>::constructor_signature;
+  using type = typename InterfaceTraits<T>::constructor_parameters;
 };
 
 }  // namespace impl
 
 /**
- * @brief Type trait for extracting the `constructor_signature` of
+ * @brief Type trait for extracting the `constructor_parameters` of
  * InterfaceTraits.
  *
  * @tparam T same as in InterfaceTraits
  *
  * Helper type:\n
- * @ref interface_constructor_signature_t<T> = interface_constructor_signature<T>::type;
+ * @ref interface_constructor_parameters_t<T> = interface_constructor_parameters<T>::type;
  */
 template<class T>
-struct interface_constructor_signature
+struct interface_constructor_parameters
 {
   /**
-   * @brief InterfaceTraits<T>::constructor_signature if present, otherwise the
+   * @brief InterfaceTraits<T>::constructor_parameters if present, otherwise the
    * default value (see InterfaceTraits).
    */
-  using type = typename impl::interface_constructor_signature_impl<T>::type;
+  using type = typename impl::interface_constructor_parameters_impl<T>::type;
 };
 
 /**
- * @brief Helper type alias @ref interface_constructor_signature<T>::type
- * @see interface_constructor_signature
+ * @brief Helper type alias @ref interface_constructor_parameters<T>::type
+ * @see interface_constructor_parameters
  */
 template<class T>
-using interface_constructor_signature_t =
-  typename interface_constructor_signature<T>::type;
+using interface_constructor_parameters_t =
+  typename interface_constructor_parameters<T>::type;
+
+namespace impl
+{
+
+template<class ... Ts>
+struct is_interface_constructible_impl
+{
+  static_assert(false_v<Ts...>, "Base template selected.");
+};
+
+template<class ... Params, class ... Args>
+struct is_interface_constructible_impl<ConstructorParameters<Params...>, Args...>
+  : std::is_invocable<void(Params...), Args...>
+{
+};
+
+}  // namespace impl
 
 /**
  * @brief Type trait for checking whether plugins derived from T can be
@@ -150,7 +178,7 @@ using interface_constructor_signature_t =
  */
 template<class Base, class ... Args>
 struct is_interface_constructible
-  : std::is_invocable<interface_constructor_signature_t<Base>, Args...>
+  : impl::is_interface_constructible_impl<interface_constructor_parameters_t<Base>, Args...>
 {
 };
 
@@ -161,14 +189,6 @@ struct is_interface_constructible
 template<class Base, class ... Args>
 constexpr bool is_interface_constructible_v =
   is_interface_constructible<Base, Args...>::value;
-
-namespace impl
-{
-
-template<class ...>
-constexpr bool false_v = false;
-
-}  // namespace impl
 
 }  // namespace class_loader
 

--- a/include/class_loader/interface_traits.hpp
+++ b/include/class_loader/interface_traits.hpp
@@ -1,0 +1,167 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2025, Multi-robot Systems (MRS) group at Czech Technical University in Prague
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLASS_LOADER__INTERFACE_TRAITS_HPP_
+#define CLASS_LOADER__INTERFACE_TRAITS_HPP_
+
+#include <type_traits>
+
+namespace class_loader
+{
+
+/**
+ * @brief Customization point that allows setting additional properties of
+ * an interface class.
+ *
+ * @tparam T Base class for which the traits are defined
+ *
+ * Users can crete specializations of this class for the base type for which
+ * the properties should be set. Properties are optional and therefore might not
+ * exist in a given specialization. To access these properties, use their
+ * respective accessor traits which provide the default value when it is not
+ * specified.
+ *
+ * Supported properties:
+ * - `constructor_signature` (member type)
+ *   - accessor: interface_constructor_signature
+ *   - default: T()
+ *   - defines the signature with which will the class loader instantiate the
+ *     derived classes
+ *   - example:
+ *     \code
+ *     using constructor_signature = T(double, int);
+ *     \endcode
+ *     defines that derived classes of class T (replace with the base class type
+ *     used in this specialization) will be instantiated with `double` and `int`
+ *     as their constructor arguments
+ *
+ * Example:
+ * \code
+ * class BaseWithInterfaceCtor
+ * {
+ * public:
+ *   // constructor parameters for the base class do not need to match the derived classes
+ *   explicit BaseWithInterfaceCtor(std::string) {}
+ *   virtual ~BaseWithInterfaceCtor() = default;
+ *
+ *   virtual int get_number() = 0;
+ * };
+ *
+ * // Specialize the class_loader::InterfaceTraits struct to define properties of your interface
+ * template<>
+ * struct class_loader::InterfaceTraits<BaseWithInterfaceCtor>
+ * {
+ *   // derived classes will be instantiated with two parameters (string and unique_ptr<int>)
+ *   using constructor_signature = BaseWithInterfaceCtor(std::string, std::unique_ptr<int>);
+ * };
+ * \endcode
+ */
+template<class T>
+struct InterfaceTraits
+{
+};
+
+namespace impl
+{
+
+template<class T, class = void>
+struct interface_constructor_signature_impl
+{
+  using type = T();
+};
+
+template<class T>
+struct interface_constructor_signature_impl<T,
+  std::void_t<typename InterfaceTraits<T>::constructor_signature>>
+{
+  using type = typename InterfaceTraits<T>::constructor_signature;
+};
+
+}  // namespace impl
+
+/**
+ * @brief Type trait for extracting the `constructor_signature` of
+ * InterfaceTraits.
+ *
+ * @tparam T same as in InterfaceTraits
+ *
+ * Helper type:\n
+ * @ref interface_constructor_signature_t<T> = interface_constructor_signature<T>::type;
+ */
+template<class T>
+struct interface_constructor_signature
+{
+  /**
+   * @brief InterfaceTraits<T>::constructor_signature if present, otherwise the
+   * default value (see InterfaceTraits).
+   */
+  using type = typename impl::interface_constructor_signature_impl<T>::type;
+};
+
+/**
+ * @brief Helper type alias @ref interface_constructor_signature<T>::type
+ * @see interface_constructor_signature
+ */
+template<class T>
+using interface_constructor_signature_t =
+  typename interface_constructor_signature<T>::type;
+
+/**
+ * @brief Type trait for checking whether plugins derived from T can be
+ * constructed with specified arguments.
+ *
+ * @tparam Base same as in InterfaceTraits
+ * @tparam Args list of arguments to check
+ *
+ * Contains static constexpr member variable `value` that is true if plugins
+ * derived from `T` can be constructed using `Args`, false otherwise.
+ *
+ * Helper variable template:\n
+ * @ref is_interface_constructible_v<T, Args...> =
+ * @ref is_interface_constructible "is_interface_constructible<T, Args...>::value"
+ */
+template<class Base, class ... Args>
+struct is_interface_constructible
+  : std::is_invocable<interface_constructor_signature_t<Base>, Args...>
+{
+};
+
+/**
+ * @brief Helper variable template for @ref is_interface_constructible "is_interface_constructible<T, Args...>::value"
+ * @see is_interface_constructible
+ */
+template<class Base, class ... Args>
+constexpr bool is_interface_constructible_v =
+  is_interface_constructible<Base, Args...>::value;
+
+}  // namespace class_loader
+
+#endif  // CLASS_LOADER__INTERFACE_TRAITS_HPP_

--- a/include/class_loader/interface_traits.hpp
+++ b/include/class_loader/interface_traits.hpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2025, Multi-robot Systems (MRS) group at Czech Technical University in Prague
+ * Copyright (c) 2026, Multi-robot Systems (MRS) group at Czech Technical University in Prague
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/include/class_loader/interface_traits.hpp
+++ b/include/class_loader/interface_traits.hpp
@@ -162,6 +162,14 @@ template<class Base, class ... Args>
 constexpr bool is_interface_constructible_v =
   is_interface_constructible<Base, Args...>::value;
 
+namespace impl
+{
+
+template<class ...>
+constexpr bool false_v = false;
+
+}  // namespace impl
+
 }  // namespace class_loader
 
 #endif  // CLASS_LOADER__INTERFACE_TRAITS_HPP_

--- a/include/class_loader/meta_object.hpp
+++ b/include/class_loader/meta_object.hpp
@@ -154,9 +154,9 @@ protected:
   AbstractMetaObjectBaseImpl * impl_;
 };
 
-template<class ...>
+template<class ... Ts>
 class AbstractMetaObjectImpl {
-  static_assert(false, "Base template selected.");
+  static_assert(false_v<Ts...>, "Base template selected.");
 };
 
 template<class B, class ... Args>
@@ -204,9 +204,9 @@ private:
   AbstractMetaObject & operator=(const AbstractMetaObject &);
 };
 
-template<class ...>
+template<class ... Ts>
 class MetaObjectImpl {
-  static_assert(false, "Base template selected.");
+  static_assert(false_v<Ts...>, "Base template selected.");
 };
 
 template<class C, class B, class ... Args>

--- a/include/class_loader/meta_object.hpp
+++ b/include/class_loader/meta_object.hpp
@@ -36,8 +36,10 @@
 
 #include <string>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
+#include "class_loader/interface_traits.hpp"
 #include "class_loader/visibility_control.hpp"
 
 namespace class_loader
@@ -152,6 +154,27 @@ protected:
   AbstractMetaObjectBaseImpl * impl_;
 };
 
+template<class ...>
+class AbstractMetaObjectImpl {
+  static_assert(false, "Base template selected.");
+};
+
+template<class B, class ... Args>
+class AbstractMetaObjectImpl<B(Args...)>: public AbstractMetaObjectBase {
+protected:
+  using AbstractMetaObjectBase::AbstractMetaObjectBase;
+
+public:
+  /**
+   * @brief Defines the factory interface that the MetaObject must implement.
+   *
+   * @return A pointer of parametric type B to a newly created object.
+   */
+  virtual B * create(Args... args) const = 0;
+  /// Create a new instance of a class.
+  /// Cannot be used for singletons.
+};
+
 /**
  * @class AbstractMetaObject
  * @brief Abstract base class for factories where polymorphic type variable indicates base class for
@@ -160,8 +183,10 @@ protected:
  * @parm B The base class interface for the plugin
  */
 template<class B>
-class AbstractMetaObject : public AbstractMetaObjectBase
+class AbstractMetaObject : public AbstractMetaObjectImpl<interface_constructor_signature_t<B>>
 {
+  using Base = AbstractMetaObjectImpl<interface_constructor_signature_t<B>>;
+
 public:
   /**
    * @brief A constructor for this class
@@ -169,23 +194,40 @@ public:
    * @param name The literal name of the class.
    */
   AbstractMetaObject(const std::string & class_name, const std::string & base_class_name)
-  : AbstractMetaObjectBase(class_name, base_class_name, typeid(B).name())
+  : Base(class_name, base_class_name, typeid(B).name())
   {
   }
-
-  /**
-   * @brief Defines the factory interface that the MetaObject must implement.
-   *
-   * @return A pointer of parametric type B to a newly created object.
-   */
-  virtual B * create() const = 0;
-  /// Create a new instance of a class.
-  /// Cannot be used for singletons.
 
 private:
   AbstractMetaObject();
   AbstractMetaObject(const AbstractMetaObject &);
   AbstractMetaObject & operator=(const AbstractMetaObject &);
+};
+
+template<class ...>
+class MetaObjectImpl {
+  static_assert(false, "Base template selected.");
+};
+
+template<class C, class B, class ... Args>
+class MetaObjectImpl<C, B(Args...)>: public AbstractMetaObject<B>
+{
+protected:
+  using AbstractMetaObject<B>::AbstractMetaObject;
+
+public:
+  static_assert(std::is_constructible_v<C, Args...>,
+    "Plugin must be constructible with arguments defined by the interface.");
+  /**
+   * @brief The factory interface to generate an object. The object has type C in reality, though a
+   * pointer of the base class type is returned.
+   *
+   * @return A pointer to a newly created plugin with the base class type (type parameter B)
+   */
+  B * create(Args... args) const override
+  {
+    return new C(std::forward<Args>(args)...);
+  }
 };
 
 /**
@@ -196,26 +238,17 @@ private:
  * @parm B The base class interface for the plugin
  */
 template<class C, class B>
-class MetaObject : public AbstractMetaObject<B>
+class MetaObject : public MetaObjectImpl<C, interface_constructor_signature_t<B>>
 {
+  using Base = MetaObjectImpl<C, interface_constructor_signature_t<B>>;
+
 public:
   /**
    * @brief Constructor for the class
    */
   MetaObject(const std::string & class_name, const std::string & base_class_name)
-  : AbstractMetaObject<B>(class_name, base_class_name)
+  : Base(class_name, base_class_name)
   {
-  }
-
-  /**
-   * @brief The factory interface to generate an object. The object has type C in reality, though a
-   * pointer of the base class type is returned.
-   *
-   * @return A pointer to a newly created plugin with the base class type (type parameter B)
-   */
-  B * create() const
-  {
-    return new C;
   }
 };
 

--- a/include/class_loader/meta_object.hpp
+++ b/include/class_loader/meta_object.hpp
@@ -160,7 +160,7 @@ class AbstractMetaObjectImpl {
 };
 
 template<class B, class ... Args>
-class AbstractMetaObjectImpl<B(Args...)>: public AbstractMetaObjectBase {
+class AbstractMetaObjectImpl<B, ConstructorParameters<Args...>>: public AbstractMetaObjectBase {
 protected:
   using AbstractMetaObjectBase::AbstractMetaObjectBase;
 
@@ -183,9 +183,9 @@ public:
  * @parm B The base class interface for the plugin
  */
 template<class B>
-class AbstractMetaObject : public AbstractMetaObjectImpl<interface_constructor_signature_t<B>>
+class AbstractMetaObject : public AbstractMetaObjectImpl<B, interface_constructor_parameters_t<B>>
 {
-  using Base = AbstractMetaObjectImpl<interface_constructor_signature_t<B>>;
+  using Base = AbstractMetaObjectImpl<B, interface_constructor_parameters_t<B>>;
 
 public:
   /**
@@ -210,7 +210,7 @@ class MetaObjectImpl {
 };
 
 template<class C, class B, class ... Args>
-class MetaObjectImpl<C, B(Args...)>: public AbstractMetaObject<B>
+class MetaObjectImpl<C, B, ConstructorParameters<Args...>>: public AbstractMetaObject<B>
 {
 protected:
   using AbstractMetaObject<B>::AbstractMetaObject;
@@ -238,9 +238,9 @@ public:
  * @parm B The base class interface for the plugin
  */
 template<class C, class B>
-class MetaObject : public MetaObjectImpl<C, interface_constructor_signature_t<B>>
+class MetaObject : public MetaObjectImpl<C, B, interface_constructor_parameters_t<B>>
 {
-  using Base = MetaObjectImpl<C, interface_constructor_signature_t<B>>;
+  using Base = MetaObjectImpl<C, B, interface_constructor_parameters_t<B>>;
 
 public:
   /**

--- a/include/class_loader/multi_library_class_loader.hpp
+++ b/include/class_loader/multi_library_class_loader.hpp
@@ -36,6 +36,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 // TODO(mikaelarguedas) remove this once console_bridge complies with this
@@ -87,10 +88,13 @@ public:
    *
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
+   * @param args - arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return A std::shared_ptr<Base> to newly created plugin
    */
-  template<class Base>
-  std::shared_ptr<Base> createInstance(const std::string & class_name)
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+  std::shared_ptr<Base> createInstance(const std::string & class_name, Args &&... args)
   {
     CONSOLE_BRIDGE_logDebug(
       "class_loader::MultiLibraryClassLoader: "
@@ -105,7 +109,7 @@ public:
               "was explicitly loaded through MultiLibraryClassLoader::loadLibrary()");
     }
 
-    return loader->createInstance<Base>(class_name);
+    return loader->createInstance<Base>(class_name, std::forward<Args>(args)...);
   }
 
   /**
@@ -115,11 +119,14 @@ public:
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
    * @param library_path - the library from which we want to create the plugin
+   * @param args - arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return A std::shared_ptr<Base> to newly created plugin
    */
-  template<class Base>
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
   std::shared_ptr<Base> createInstance(
-    const std::string & class_name, const std::string & library_path)
+    const std::string & class_name, const std::string & library_path, Args &&... args)
   {
     ClassLoader * loader = getClassLoaderForLibrary(library_path);
     if (nullptr == loader) {
@@ -128,7 +135,7 @@ public:
               "MultiLibraryClassLoader bound to library " + library_path +
               " Ensure you called MultiLibraryClassLoader::loadLibrary()");
     }
-    return loader->createInstance<Base>(class_name);
+    return loader->createInstance<Base>(class_name, std::forward<Args>(args)...);
   }
 
   /// Creates an instance of an object of given class name with ancestor class Base
@@ -138,10 +145,13 @@ public:
    *
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
+   * @param args - arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return A unique pointer to newly created plugin
    */
-  template<class Base>
-  ClassLoader::UniquePtr<Base> createUniqueInstance(const std::string & class_name)
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+  ClassLoader::UniquePtr<Base> createUniqueInstance(const std::string & class_name, Args &&... args)
   {
     CONSOLE_BRIDGE_logDebug(
       "class_loader::MultiLibraryClassLoader: Attempting to create instance of class type %s.",
@@ -154,7 +164,7 @@ public:
               "Make sure that the library exists and was explicitly loaded through "
               "MultiLibraryClassLoader::loadLibrary()");
     }
-    return loader->createUniqueInstance<Base>(class_name);
+    return loader->createUniqueInstance<Base>(class_name, std::forward<Args>(args)...);
   }
 
   /// Creates an instance of an object of given class name with ancestor class Base
@@ -164,11 +174,16 @@ public:
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
    * @param library_path - the library from which we want to create the plugin
+   * @param args - arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return A unique pointer to newly created plugin
    */
-  template<class Base>
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
   ClassLoader::UniquePtr<Base>
-  createUniqueInstance(const std::string & class_name, const std::string & library_path)
+  createUniqueInstance(
+    const std::string & class_name, const std::string & library_path,
+    Args &&... args)
   {
     ClassLoader * loader = getClassLoaderForLibrary(library_path);
     if (nullptr == loader) {
@@ -177,7 +192,7 @@ public:
               "MultiLibraryClassLoader bound to library " + library_path +
               " Ensure you called MultiLibraryClassLoader::loadLibrary()");
     }
-    return loader->createUniqueInstance<Base>(class_name);
+    return loader->createUniqueInstance<Base>(class_name, std::forward<Args>(args)...);
   }
 
   /**
@@ -188,17 +203,20 @@ public:
    *
    * @param Base - polymorphic type indicating base class
    * @param class_name - the name of the concrete plugin class we want to instantiate
+   * @param args - arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    * @return An unmanaged Base* to newly created plugin
    */
-  template<class Base>
-  Base * createUnmanagedInstance(const std::string & class_name)
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+  Base * createUnmanagedInstance(const std::string & class_name, Args &&... args)
   {
     ClassLoader * loader = getClassLoaderForClass<Base>(class_name);
     if (nullptr == loader) {
       throw class_loader::CreateClassException(
               "MultiLibraryClassLoader: Could not create class of type " + class_name);
     }
-    return loader->createUnmanagedInstance<Base>(class_name);
+    return loader->createUnmanagedInstance<Base>(class_name, std::forward<Args>(args)...);
   }
 
   /**
@@ -209,9 +227,14 @@ public:
    * @param Base - polymorphic type indicating Base class
    * @param class_name - name of class for which we want to create instance
    * @param library_path - the fully qualified path to the runtime library
+   * @param args - arguments for the constructor of the derived class (types defined
+   * by InterfaceTraits of the Base class)
    */
-  template<class Base>
-  Base * createUnmanagedInstance(const std::string & class_name, const std::string & library_path)
+  template<class Base, class ... Args,
+    std::enable_if_t<is_interface_constructible_v<Base, Args...>, bool> = true>
+  Base * createUnmanagedInstance(
+    const std::string & class_name, const std::string & library_path,
+    Args &&... args)
   {
     ClassLoader * loader = getClassLoaderForLibrary(library_path);
     if (nullptr == loader) {
@@ -220,7 +243,7 @@ public:
               "bound to library " + library_path +
               " Ensure you called MultiLibraryClassLoader::loadLibrary()");
     }
-    return loader->createUnmanagedInstance<Base>(class_name);
+    return loader->createUnmanagedInstance<Base>(class_name, std::forward<Args>(args)...);
   }
 
   /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,10 @@ add_library(${PROJECT_NAME}_TestPlugins2 EXCLUDE_FROM_ALL SHARED plugins2.cpp)
 target_link_libraries(${PROJECT_NAME}_TestPlugins2 ${PROJECT_NAME})
 class_loader_hide_library_symbols(${PROJECT_NAME}_TestPlugins2)
 
+add_library(${PROJECT_NAME}_TestPlugins3 EXCLUDE_FROM_ALL SHARED plugins3.cpp)
+target_link_libraries(${PROJECT_NAME}_TestPlugins3 ${PROJECT_NAME})
+class_loader_hide_library_symbols(${PROJECT_NAME}_TestPlugins3)
+
 # These plugins are loaded using dlopen() with RTLD_GLOBAL in utest and may cause side effects
 # in other tests if they are used elsewhere.
 add_library(${PROJECT_NAME}_TestGlobalPlugins EXCLUDE_FROM_ALL SHARED global_plugins.cpp)
@@ -50,6 +54,7 @@ if(TARGET ${PROJECT_NAME}_utest)
   add_dependencies(${PROJECT_NAME}_utest
     ${PROJECT_NAME}_TestPlugins1
     ${PROJECT_NAME}_TestPlugins2
+    ${PROJECT_NAME}_TestPlugins3
     ${PROJECT_NAME}_TestGlobalPlugins)
 endif()
 
@@ -72,7 +77,8 @@ if(TARGET ${PROJECT_NAME}_unique_ptr_test)
   endif()
   add_dependencies(${PROJECT_NAME}_unique_ptr_test
     ${PROJECT_NAME}_TestPlugins1
-    ${PROJECT_NAME}_TestPlugins2)
+    ${PROJECT_NAME}_TestPlugins2
+    ${PROJECT_NAME}_TestPlugins3)
 endif()
 
 add_subdirectory(fviz_case_study)

--- a/test/base.hpp
+++ b/test/base.hpp
@@ -62,7 +62,21 @@ struct class_loader::InterfaceTraits<BaseWithInterfaceCtor>
   // - string to check that arguments are not mixed up with class names and
   //   that they do not create ambiguous calls
   // - unique_ptr to check that the construction works correctly with move only types
-  using constructor_signature = BaseWithInterfaceCtor(std::string, std::unique_ptr<int>);
+  using constructor_parameters = class_loader::ConstructorParameters<std::string,
+      std::unique_ptr<int>>;
 };
+
+static_assert(
+  class_loader::is_interface_constructible_v<BaseWithInterfaceCtor, std::string,
+  std::unique_ptr<int>>,
+  "BaseWithInterfaceCtor should be interface constructible with the specifed types."
+);
+
+static_assert(
+  class_loader::is_interface_constructible_v<BaseWithInterfaceCtor, const std::string &,
+  std::unique_ptr<int>&&>,
+  "BaseWithInterfaceCtor should be interface constructible with the specifed types."
+);
+
 
 #endif  // BASE_HPP_

--- a/test/plugins3.cpp
+++ b/test/plugins3.cpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2025, Multi-robot Systems (MRS) group at Czech Technical University in Prague
+ * Copyright (c) 2026, Multi-robot Systems (MRS) group at Czech Technical University in Prague
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <memory>
+#include <string>
 
 #include "class_loader/register_macro.hpp"
 

--- a/test/plugins3.cpp
+++ b/test/plugins3.cpp
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2012, Willow Garage, Inc.
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2025, Multi-robot Systems (MRS) group at Czech Technical University in Prague
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -10,14 +12,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *     * Neither the name of the copyright holder nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
@@ -27,42 +29,39 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef BASE_HPP_
-#define BASE_HPP_
+#include "class_loader/register_macro.hpp"
 
-#include <memory>
-#include <string>
+#include "./base.hpp"
 
-#include "class_loader/interface_traits.hpp"
-
-// This was originally at 1000, but arm32 platforms we have tested on are not able to
-// successfully spin up 1000 threads in this test process. Using 500 as a reliably passing number.
-static constexpr size_t STRESS_TEST_NUM_THREADS = 500;
-
-class Base
+class Identity : public BaseWithInterfaceCtor
 {
 public:
-  virtual ~Base() {}
-  virtual void saySomething() = 0;
+  explicit Identity(std::string name, std::unique_ptr<int> number)
+  : BaseWithInterfaceCtor(name), number_(*number) {}
+
+  int get_number() override
+  {
+    return number_;
+  }
+
+private:
+  int number_;
 };
 
-class BaseWithInterfaceCtor
+class Double : public BaseWithInterfaceCtor
 {
 public:
-  // constructor parameters for the base class do not need to match the derived classes
-  explicit BaseWithInterfaceCtor(std::string) {}
-  virtual ~BaseWithInterfaceCtor() = default;
+  explicit Double(std::string name, std::unique_ptr<int> number)
+  : BaseWithInterfaceCtor(name), number_(*number) {}
 
-  virtual int get_number() = 0;
+  int get_number() override
+  {
+    return 2 * number_;
+  }
+
+private:
+  int number_;
 };
 
-template<>
-struct class_loader::InterfaceTraits<BaseWithInterfaceCtor>
-{
-  // - string to check that arguments are not mixed up with class names and
-  //   that they do not create ambiguous calls
-  // - unique_ptr to check that the construction works correctly with move only types
-  using constructor_signature = BaseWithInterfaceCtor(std::string, std::unique_ptr<int>);
-};
-
-#endif  // BASE_HPP_
+CLASS_LOADER_REGISTER_CLASS(Identity, BaseWithInterfaceCtor)
+CLASS_LOADER_REGISTER_CLASS(Double, BaseWithInterfaceCtor)

--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -45,6 +45,7 @@
 
 const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");  // NOLINT
 const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");  // NOLINT
+const std::string LIBRARY_3 = class_loader::systemLibraryFormat("class_loader_TestPlugins3");  // NOLINT
 
 using class_loader::ClassLoader;
 
@@ -80,6 +81,25 @@ TEST(ClassLoaderUniquePtrTest, basicLoadTwiceSameTime) {
     loader1.createUniqueInstance<Base>("Cat")->saySomething();  // See if lazy load works
     ClassLoader loader2(LIBRARY_1, false);
     loader2.createUniqueInstance<Base>("Cat")->saySomething();  // See if lazy load works
+    ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
+    SUCCEED();
+  } catch (class_loader::ClassLoaderException & e) {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+}
+
+TEST(ClassLoaderUniquePtrTest, constructorLoad) {
+  try {
+    ClassLoader loader1(LIBRARY_3, false);
+    ASSERT_EQ(loader1.createUniqueInstance<BaseWithInterfaceCtor>("Identity", "identity 1",
+      std::make_unique<int>(1))->get_number(), 1);
+    ASSERT_EQ(loader1.createUniqueInstance<BaseWithInterfaceCtor>("Identity", "identity 2",
+      std::make_unique<int>(10))->get_number(),
+      10);
+    ASSERT_EQ(loader1.createUniqueInstance<BaseWithInterfaceCtor>("Double", "double 1",
+      std::make_unique<int>(1))->get_number(), 2);
+    ASSERT_EQ(loader1.createUniqueInstance<BaseWithInterfaceCtor>("Double", "double 2",
+      std::make_unique<int>(10))->get_number(), 20);
     ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
     SUCCEED();
   } catch (class_loader::ClassLoaderException & e) {
@@ -242,10 +262,20 @@ void testMultiClassLoader(bool lazy)
     class_loader::MultiLibraryClassLoader loader(lazy);
     loader.loadLibrary(LIBRARY_1);
     loader.loadLibrary(LIBRARY_2);
+    loader.loadLibrary(LIBRARY_3);
     for (int i = 0; i < 2; ++i) {
       loader.createUniqueInstance<Base>("Cat")->saySomething();
       loader.createUniqueInstance<Base>("Dog")->saySomething();
       loader.createUniqueInstance<Base>("Robot")->saySomething();
+      ASSERT_EQ(loader.createUniqueInstance<BaseWithInterfaceCtor>("Identity", "identity 1",
+        std::make_unique<int>(1))->get_number(), 1);
+      ASSERT_EQ(loader.createUniqueInstance<BaseWithInterfaceCtor>("Identity", "identity 2",
+        std::make_unique<int>(10))->get_number(),
+        10);
+      ASSERT_EQ(loader.createUniqueInstance<BaseWithInterfaceCtor>("Double", "double 1",
+        std::make_unique<int>(1))->get_number(), 2);
+      ASSERT_EQ(loader.createUniqueInstance<BaseWithInterfaceCtor>("Double", "double 2",
+        std::make_unique<int>(10))->get_number(), 20);
     }
   } catch (class_loader::ClassLoaderException & e) {
     FAIL() << "ClassLoaderException: " << e.what() << "\n";

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -49,6 +49,7 @@
 
 const std::string LIBRARY_1 = class_loader::systemLibraryFormat("class_loader_TestPlugins1");  // NOLINT
 const std::string LIBRARY_2 = class_loader::systemLibraryFormat("class_loader_TestPlugins2");  // NOLINT
+const std::string LIBRARY_3 = class_loader::systemLibraryFormat("class_loader_TestPlugins3");  // NOLINT
 
 // These are loaded with dlopen() and RTLD_GLOBAL in loadUnloadLoadFromGraveyard and may cause
 // unexpected side-effects if used elsewhere
@@ -99,6 +100,25 @@ TEST(ClassLoaderTest, basicLoadTwiceSameTime) {
   SUCCEED();
 }
 
+TEST(ClassLoaderTest, constructorLoad) {
+  try {
+    class_loader::ClassLoader loader1(LIBRARY_3, false);
+    ASSERT_NO_THROW(class_loader::impl::printDebugInfoToScreen());
+    ASSERT_EQ(loader1.createInstance<BaseWithInterfaceCtor>("Identity", "identity 1",
+      std::make_unique<int>(1))->get_number(), 1);
+    ASSERT_EQ(loader1.createInstance<BaseWithInterfaceCtor>("Identity", "identity 2",
+      std::make_unique<int>(10))->get_number(), 10);
+    ASSERT_EQ(loader1.createInstance<BaseWithInterfaceCtor>("Double", "double 1",
+      std::make_unique<int>(1))->get_number(), 2);
+    ASSERT_EQ(loader1.createInstance<BaseWithInterfaceCtor>("Double", "double 2",
+      std::make_unique<int>(10))->get_number(), 20);
+  } catch (class_loader::ClassLoaderException & e) {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+
+  SUCCEED();
+}
+
 // Requires separate namespace so static variables are isolated
 TEST(ClassLoaderUnmanagedTest, basicLoadUnmanaged) {
   try {
@@ -106,6 +126,23 @@ TEST(ClassLoaderUnmanagedTest, basicLoadUnmanaged) {
     Base * unmanaged_instance = loader1.createUnmanagedInstance<Base>("Dog");
     ASSERT_NE(unmanaged_instance, nullptr);
     unmanaged_instance->saySomething();
+    delete unmanaged_instance;
+  } catch (class_loader::ClassLoaderException & e) {
+    FAIL() << "ClassLoaderException: " << e.what() << "\n";
+  }
+
+  SUCCEED();
+}
+
+// Requires separate namespace so static variables are isolated
+TEST(ClassLoaderUnmanagedTest, constructorLoadUnmanaged) {
+  try {
+    class_loader::ClassLoader loader1(LIBRARY_3, false);
+    BaseWithInterfaceCtor * unmanaged_instance =
+      loader1.createUnmanagedInstance<BaseWithInterfaceCtor>("Identity", "identity",
+      std::make_unique<int>(1));
+    ASSERT_NE(unmanaged_instance, nullptr);
+    ASSERT_EQ(unmanaged_instance->get_number(), 1);
     delete unmanaged_instance;
   } catch (class_loader::ClassLoaderException & e) {
     FAIL() << "ClassLoaderException: " << e.what() << "\n";
@@ -348,10 +385,19 @@ void testMultiClassLoader(bool lazy)
     class_loader::MultiLibraryClassLoader loader(lazy);
     loader.loadLibrary(LIBRARY_1);
     loader.loadLibrary(LIBRARY_2);
+    loader.loadLibrary(LIBRARY_3);
     for (int i = 0; i < 2; ++i) {
       loader.createInstance<Base>("Cat")->saySomething();
       loader.createInstance<Base>("Dog")->saySomething();
       loader.createInstance<Base>("Robot")->saySomething();
+      ASSERT_EQ(loader.createInstance<BaseWithInterfaceCtor>("Identity", "identity 1",
+        std::make_unique<int>(1))->get_number(), 1);
+      ASSERT_EQ(loader.createInstance<BaseWithInterfaceCtor>("Identity", "identity 2",
+        std::make_unique<int>(10))->get_number(), 10);
+      ASSERT_EQ(loader.createInstance<BaseWithInterfaceCtor>("Double", "double 1",
+        std::make_unique<int>(1))->get_number(), 2);
+      ASSERT_EQ(loader.createInstance<BaseWithInterfaceCtor>("Double", "double 2",
+        std::make_unique<int>(10))->get_number(), 20);
     }
   } catch (class_loader::ClassLoaderException & e) {
     FAIL() << "ClassLoaderException: " << e.what() << "\n";


### PR DESCRIPTION
This PR adds the ability to pass arguments to constructors of the derived classes. As a result, users can now create plugins that are not default constructible, removing the need for initialize method.

To achieve this, a new customization point was added: template struct `InterfaceTraits`. Specializing this struct allows users to define signature of the constructors that will be required by the derived classes.

If users do not specialize this structure, default constructor is assumed and there are no changes to the behavior.