### PR TITLE
Reduce thread safety test output

### DIFF
--- a/test/unique_ptr_test.cpp
+++ b/test/unique_ptr_test.cpp
@@ -187,7 +187,7 @@ void run(ClassLoader * loader)
 {
   std::vector<std::string> classes = loader->getAvailableClasses<Base>();
   for (auto & class_ : classes) {
-    loader->createUniqueInstance<Base>(class_)->saySomething();
+    (void)loader->createUniqueInstance<Base>(class_);
   }
 }
 

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -272,7 +272,7 @@ void run(class_loader::ClassLoader * loader)
 {
   std::vector<std::string> classes = loader->getAvailableClasses<Base>();
   for (auto & class_ : classes) {
-    loader->createInstance<Base>(class_)->saySomething();
+    (void)loader->createInstance<Base>(class_);
   }
 }
 


### PR DESCRIPTION
Fixes #145.

## Summary

The thread-safety stress tests created plugin instances across 500 threads and called `saySomething()` for every instance, flooding the test output with repeated plugin messages.

Keep the shared-pointer and unique-pointer construction and destruction stress intact, but remove the unnecessary output-producing method calls.

## Testing

Validated in `ros:rolling-ros-base`:

- `colcon build --packages-select class_loader --cmake-args -DBUILD_TESTING=ON`
- `colcon test --packages-select class_loader`
- 134 tests, 0 errors, 0 failures
- `ClassLoaderTest.threadSafety` passed
- `ClassLoaderUniquePtrTest.threadSafety` passed
- `git diff --check`

## Generative AI

Generative AI assisted with issue analysis, preparing the scoped edit, and test planning. I reviewed the complete diff and all test results.
