### PR TITLE
Fix isLibraryLoaded per-loader scope

### DIFF
--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -298,7 +298,7 @@ bool isLibraryLoaded(const std::string & library_path, const ClassLoader * loade
     allMetaObjectsForLibraryOwnedBy(library_path, loader).size();
   bool are_meta_objs_bound_to_loader =
     (0 == num_meta_objs_for_lib) ? true : (
-    num_meta_objs_for_lib_bound_to_loader <= num_meta_objs_for_lib);
+    num_meta_objs_for_lib_bound_to_loader == num_meta_objs_for_lib);
 
   return is_lib_loaded_by_anyone && are_meta_objs_bound_to_loader;
 }

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -381,6 +381,26 @@ TEST(ClassLoaderTest, loadRefCountingLazy) {
   FAIL() << "Did not throw exception as expected.\n";
 }
 
+TEST(ClassLoaderTest, isLibraryLoadedScopedToLoader) {
+  class_loader::ClassLoader loader1(LIBRARY_1, false);
+  ASSERT_TRUE(loader1.isLibraryLoaded());
+
+  class_loader::ClassLoader loader2(LIBRARY_1, true);
+  ASSERT_TRUE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+  ASSERT_FALSE(loader2.isLibraryLoaded());
+
+  loader2.loadLibrary();
+  ASSERT_TRUE(loader2.isLibraryLoaded());
+
+  loader2.unloadLibrary();
+  ASSERT_FALSE(loader2.isLibraryLoaded());
+  ASSERT_TRUE(loader1.isLibraryLoaded());
+  ASSERT_TRUE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+
+  loader1.unloadLibrary();
+  ASSERT_FALSE(class_loader::impl::isLibraryLoadedByAnybody(LIBRARY_1));
+}
+
 void testMultiClassLoader(bool lazy)
 {
   try {


### PR DESCRIPTION
Fixes #173.

## Summary

`ClassLoader::isLibraryLoaded()` is documented to report whether a library is loaded within the scope of that specific loader.

The previous comparison used `<=` when comparing the number of metaobjects owned by the loader with the total number of metaobjects for the library. Because the loader-owned metaobjects are a subset of the total, this could report the library as loaded for an on-demand loader that had not loaded it.

Require the counts to match and add a regression test using two loaders for the same library. The test verifies that:

- the on-demand loader initially reports the library as not loaded
- it reports loaded after `loadLibrary()`
- unloading it does not affect the other loader
- the library is no longer globally loaded after the final loader unloads it

## Testing

Validated in `ros:rolling-ros-base`:

- `colcon build --packages-select class_loader --cmake-args -DBUILD_TESTING=ON`
- `colcon test --packages-select class_loader`
- 135 tests, 0 errors, 0 failures, 25 skipped
- `ClassLoaderTest.isLibraryLoadedScopedToLoader` passed
- `git diff --check`

## Generative AI

Generative AI assisted with issue analysis, preparing the scoped edit, and test planning. I reviewed the complete diff and all test results.
