### PR TITLE
Make loadLibrary()/unloadLibrary() safe against concurrent load and unload

### DIFF
--- a/src/class_loader_core.cpp
+++ b/src/class_loader_core.cpp
@@ -56,6 +56,16 @@ std::recursive_mutex & getPluginBaseToFactoryMapMapMutex()
   return m;
 }
 
+namespace
+{
+// Serializes loadLibrary()/unloadLibrary() so a dlopen() never overlaps a dlclose().
+std::recursive_mutex & getLoaderMutex()
+{
+  static std::recursive_mutex m;
+  return m;
+}
+}  // namespace
+
 BaseToFactoryMapMap & getGlobalPluginBaseToFactoryMapMap()
 {
   static BaseToFactoryMapMap instance;
@@ -390,6 +400,8 @@ void purgeGraveyardOfMetaobjects(
 
 void loadLibrary(const std::string & library_path, ClassLoader * loader)
 {
+  std::lock_guard<std::recursive_mutex> loader_lock(getLoaderMutex());
+
   CONSOLE_BRIDGE_logDebug(
     "class_loader.impl: "
     "Attempting to load library %s on behalf of ClassLoader handle %p...\n",
@@ -397,6 +409,7 @@ void loadLibrary(const std::string & library_path, ClassLoader * loader)
 
   // If it's already open, just update existing metaobjects to have an additional owner.
   if (isLibraryLoadedByAnybody(library_path)) {
+    std::lock_guard<std::recursive_mutex> lock(getPluginBaseToFactoryMapMapMutex());
     CONSOLE_BRIDGE_logDebug(
       "%s",
       "class_loader.impl: "
@@ -407,11 +420,7 @@ void loadLibrary(const std::string & library_path, ClassLoader * loader)
 
   std::shared_ptr<rcpputils::SharedLibrary> library_handle;
 
-  static std::recursive_mutex loader_mutex;
-
   {
-    std::lock_guard<std::recursive_mutex> loader_lock(loader_mutex);
-
     setCurrentlyActiveClassLoader(loader);
     setCurrentlyLoadingLibraryName(library_path);
     try {
@@ -463,6 +472,8 @@ void loadLibrary(const std::string & library_path, ClassLoader * loader)
 
 void unloadLibrary(const std::string & library_path, ClassLoader * loader)
 {
+  std::lock_guard<std::recursive_mutex> loader_lock(getLoaderMutex());
+
   if (hasANonPurePluginLibraryBeenOpened()) {
     CONSOLE_BRIDGE_logDebug(
       "class_loader.impl: "
@@ -479,6 +490,7 @@ void unloadLibrary(const std::string & library_path, ClassLoader * loader)
       "Unloading library %s on behalf of ClassLoader %p...",
       library_path.c_str(), reinterpret_cast<void *>(loader));
 
+    std::lock_guard<std::recursive_mutex> llv_lock(getLoadedLibraryVectorMutex());
     LibraryVector & open_libraries = getLoadedLibraryVector();
     LibraryVector::iterator itr = findLoadedLibrary(library_path);
     if (itr != open_libraries.end()) {


### PR DESCRIPTION
## Problem

`loadLibrary()` and `unloadLibrary()` can run concurrently on the same library:

- `loadLibrary()` locks only its own `dlopen()` and the final `push_back` onto the loaded
  library vector. The `isLibraryLoadedByAnybody()` test at the top is a check-then-act.
- `unloadLibrary()` takes no lock at all while it `erase()`s from that same vector and drops
  the last reference to the shared library.

Two threads therefore mutate one `std::vector` concurrently, and a `dlopen()` can overlap a
`dlclose()`. That shows up either as

```
MultiLibraryClassLoader: Could not create class of type <T>
```

when the metaobjects go away between the check and the bind, or as a SIGSEGV in
`unloadLibrary()` -> `rcpputils::SharedLibrary::unload_library()` while another thread is
inside `_dl_map_object_from_fd()` for the same plugin.

ros2/rosbag2#2350 is hitting this. We hit it in production on Jazzy, where each
`rosbag2_cpp::Writer` owns a `StorageFactory` and so loads and unloads the mcap storage
plugin once per bag.

## Change

Hold one recursive mutex across the whole of `loadLibrary()` and `unloadLibrary()`, take
`getLoadedLibraryVectorMutex()` around the erase, and guard the already-loaded branch with
`getPluginBaseToFactoryMapMapMutex()`. Lock order is loader mutex -> vector / factory map
everywhere, and the loader mutex is recursive so the plugin registration that runs from
inside `dlopen()` on the same thread is fine.

The last two hunks restore #40, which fixed #39 on `indigo-devel` in 2016 and reached
`melodic-devel` and `noetic-devel` but never the ROS 2 branches — those still carry the 2014
locking from 96ed2e4. #40 only touched the load side, so locking `unloadLibrary()` is needed
on top of that forward-port.

## Verification

Two threads doing nothing but open/close an MCAP bag through `rosbag2_cpp::Writer` on Jazzy.
Only `libclass_loader.so` differs between rows.

| class_loader | 2 threads x 200 open/close, 5 runs |
| --- | --- |
| distro 2.7.0 | 5/5 SIGSEGV |
| self-built from this branch's parent | 5/5 SIGSEGV |
| **with this change** | **0/5** |

Soak on the patched build: 8 threads x 400, 3 runs, clean. Over 200 fresh processes each
doing one concurrent open per thread: 12/200 SIGSEGV before, 0/200 after. Single-threaded
behaviour is unchanged.
